### PR TITLE
Impossible to clear lookup value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Ember Flexberry Changelog
 ### New Features & improvements
 
+## 2016-05-30
+### Fixed
+FlexberryLookupComponent:
+* When enable autocomplete, impossible to clear lookup value.
+
 ## 2016-05-24
 ### Breaking changes
 Addon change:

--- a/addon/components/flexberry-lookup.js
+++ b/addon/components/flexberry-lookup.js
@@ -343,7 +343,11 @@ export default FlexberryBaseComponent.extend({
         // Set displayValue directly because value hasn'been changes
         // and Ember won't change computed property.
         if (state !== 'selected') {
-          _this.set('displayValue', _this.buildDisplayValue());
+          if (_this.get('displayValue')) {
+            _this.set('displayValue', _this.buildDisplayValue());
+          } else {
+            _this.sendAction('remove', _this.get('removeData'));
+          }
         }
 
         state = 'closed';


### PR DESCRIPTION
When full erase a value, list with results of closed and value is restored. Now, value is restored when focus is lost, and value not full cleared.