### PR TITLE
Fix displaying column in `object-list-view`

### DIFF
--- a/app/templates/components/object-list-view.hbs
+++ b/app/templates/components/object-list-view.hbs
@@ -13,7 +13,7 @@
   <thead>
     {{#unless (and useSingleColumn emptyMobileHeader) }}
       <tr>
-        <th class="object-list-view-operations collapsing {{unless showHelperColumn 'hidden'}}" data-olv-header-property-name="OlvRowToolbar"></th>
+        <th class="object-list-view-operations collapsing {{unless (and showHelperColumn hasContent) 'hidden'}}" data-olv-header-property-name="OlvRowToolbar"></th>
         {{#if useSingleColumn}}
           {{component headerCellComponent.componentName
             column=(hash header=singleColumnHeaderTitle sortable=false)


### PR DESCRIPTION
Hide column in header if content is empty.
[TFS#107658](http://dis-tfs:8080/Common/CaseberrySupport/_workitems?_a=edit&id=107658).