### PR TITLE
Add refresh routes when using user settings

### DIFF
--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -58,6 +58,16 @@ export default Ember.Controller.extend({
   locales: ['ru', 'en'],
 
   /**
+    Handles changes in userSettingsService.isUserSettingsServiceEnabled.
+
+    @method _userSettingsServiceChanged
+    @private
+  */
+  _userSettingsServiceChanged: Ember.observer('userSettingsService.isUserSettingsServiceEnabled', function() {
+    this.get('target.router').refresh();
+  }),
+
+  /**
     Initializes controller.
   */
   init() {


### PR DESCRIPTION
TFS #110220

Added refresh page content after the switching on and off the service user settings.
This done because in the EditForms it was not possible to check work service user settings (OLV have refresh button), needed to reconnect to the page.