### PR TITLE
Feature 112826 fix example olv

### DIFF
--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -299,6 +299,11 @@ export default Ember.Controller.extend({
             caption: i18n.t('forms.application.sitemap.components-examples.flexberry-objectlistview.custom-filter.caption'),
             title: i18n.t('forms.application.sitemap.components-examples.flexberry-objectlistview.custom-filter.title'),
             children: null
+          }, {
+            link: 'components-examples/flexberry-objectlistview/configurate-rows',
+            caption: i18n.t('forms.application.sitemap.components-examples.flexberry-objectlistview.configurate-rows.caption'),
+            title: i18n.t('forms.application.sitemap.components-examples.flexberry-objectlistview.configurate-rows.title'),
+            children: null
           }]
         }, {
           link: null,

--- a/tests/dummy/app/controllers/components-examples/flexberry-objectlistview/configurate-rows.js
+++ b/tests/dummy/app/controllers/components-examples/flexberry-objectlistview/configurate-rows.js
@@ -1,0 +1,146 @@
+import Ember from 'ember';
+import ListFormController from 'ember-flexberry/controllers/list-form';
+
+export default ListFormController.extend({
+  /**
+    Name of selected detail's model projection.
+
+    @property _projectionName
+    @type String
+    @private
+   */
+  _projectionName: 'SuggestionL',
+
+  /**
+    Array of available model projections.
+
+    @property _projections
+    @type Object[]
+   */
+  _projections: Ember.computed('model.[]', function() {
+    let records = this.get('model');
+    let modelClass = Ember.get(records, 'length') > 0 ? Ember.get(records, 'firstObject').constructor : {};
+
+    return Ember.get(modelClass, 'projections');
+  }),
+
+  /**
+    Array of available model projections names.
+
+    @property _projectionsNames
+    @type String[]
+   */
+  _projectionsNames: Ember.computed('_projections.[]', function() {
+    let projections = this.get('_projections');
+    if (Ember.isNone(projections)) {
+      return [];
+    }
+
+    return Object.keys(projections);
+  }),
+
+  /**
+    Model projection for 'flexberry-objectlistview' component 'modelProjection' property.
+
+    @property projection
+    @type Object
+   */
+  projection: Ember.computed('_projections.[]', '_projectionName', function() {
+    let projectionName = this.get('_projectionName');
+    if (Ember.isBlank(projectionName)) {
+      return null;
+    }
+
+    let projections = this.get('_projections');
+    if (Ember.isNone(projections)) {
+      return null;
+    }
+
+    return projections[projectionName];
+  }),
+
+  /**
+    Name of related edit form route (for 'flexberry-objectlistview' component 'editFormRoute' property).
+
+    @property editFormRoute
+    @type String
+   */
+  editFormRoute: 'ember-flexberry-dummy-suggestion-edit',
+
+  /**
+    Current records.
+
+    @property _records
+    @type Object[]
+    @protected
+    @readOnly
+  */
+  records: [],
+
+  /**
+    Configurate rows 'flexberry-objectlistview' component by address.
+
+    @property configurateRowByAddress
+    @type String
+   */
+  configurateRowByAddress: 'Street, 20',
+
+  _configurateRowByAddress: Ember.observer('configurateRowByAddress', function() {
+    let rowConfig = { customClass: '' };
+
+    this.get('records').forEach((record, index, records) => {
+      this.send('configurateRow', rowConfig, record);
+    });
+  }),
+
+  /**
+    Template text for 'flexberry-objectlistview' component.
+
+    @property componentTemplateText
+    @type String
+   */
+  componentTemplateText: new Ember.Handlebars.SafeString(
+    '{{flexberry-objectlistview<br>' +
+    '  configurateRow=(action \"configurateRow\")<br>' +
+    '}}'),
+
+  /**
+    Component settings metadata.
+
+    @property componentSettingsMetadata
+    @type Object[]
+   */
+  componentSettingsMetadata: Ember.computed('i18n.locale', function() {
+    let componentSettingsMetadata = Ember.A();
+
+    componentSettingsMetadata.pushObject({
+      settingName: 'configurateRowByAddress',
+      settingType: 'string',
+      settingDefaultValue: 'Street, 20',
+      bindedControllerPropertieName: 'configurateRowByAddress'
+    });
+
+    return componentSettingsMetadata;
+  }),
+
+  actions: {
+    /**
+      Configurate rows on the condition.
+    */
+    configurateRow(rowConfig, record) {
+      if (record) {
+        this.get('records').push(record);
+      }
+
+      if (record.get('address') === this.get('configurateRowByAddress')) {
+        rowConfig.customClass += 'positive ';
+      }
+    }
+  },
+
+  _enableFilters: Ember.observer('enableFilters', function() {
+    if (this.get('enableFilters')) {
+      this.set('refreshButton', true);
+    }
+  }),
+});

--- a/tests/dummy/app/controllers/components-examples/flexberry-objectlistview/configurate-rows.js
+++ b/tests/dummy/app/controllers/components-examples/flexberry-objectlistview/configurate-rows.js
@@ -138,9 +138,4 @@ export default ListFormController.extend({
     }
   },
 
-  _enableFilters: Ember.observer('enableFilters', function() {
-    if (this.get('enableFilters')) {
-      this.set('refreshButton', true);
-    }
-  }),
 });

--- a/tests/dummy/app/controllers/components-examples/flexberry-objectlistview/settings-example.js
+++ b/tests/dummy/app/controllers/components-examples/flexberry-objectlistview/settings-example.js
@@ -218,22 +218,6 @@ export default ListFormController.extend({
   records: [],
 
   /**
-    Configurate rows 'flexberry-objectlistview' component by address.
-
-    @property configurateRowByAddress
-    @type String
-   */
-  configurateRowByAddress: 'Street, 20',
-
-  _configurateRowByAddress: Ember.observer('configurateRowByAddress', function() {
-    let rowConfig = { customClass: '' };
-
-    this.get('records').forEach((record, index, records) => {
-      this.send('configurateRow', rowConfig, record);
-    });
-  }),
-
-  /**
     Template text for 'flexberry-objectlistview' component.
 
     @property componentTemplateText
@@ -277,7 +261,6 @@ export default ListFormController.extend({
     '  previousPage=(action \"previousPage\")<br>' +
     '  gotoPage=(action \"gotoPage\")<br>' +
     '  nextPage=(action \"nextPage\")<br>' +
-    '  configurateRow=(action \"configurateRow\")<br>' +
     '}}'),
 
   /**
@@ -415,30 +398,9 @@ export default ListFormController.extend({
       settingDefaultValue: undefined,
       bindedControllerPropertieName: 'singleColumnHeaderTitle'
     });
-    componentSettingsMetadata.pushObject({
-      settingName: 'configurateRowByAddress',
-      settingType: 'string',
-      settingDefaultValue: 'Street, 20',
-      bindedControllerPropertieName: 'configurateRowByAddress'
-    });
 
     return componentSettingsMetadata;
   }),
-
-  actions: {
-    /**
-      Configurate rows on the condition.
-    */
-    configurateRow(rowConfig, record) {
-      if (record) {
-        this.get('records').push(record);
-      }
-
-      if (record.get('address') === this.get('configurateRowByAddress')) {
-        rowConfig.customClass += 'positive ';
-      }
-    }
-  },
 
   _enableFilters: Ember.observer('enableFilters', function() {
     if (this.get('enableFilters')) {

--- a/tests/dummy/app/controllers/components-examples/flexberry-objectlistview/settings-example.js
+++ b/tests/dummy/app/controllers/components-examples/flexberry-objectlistview/settings-example.js
@@ -244,7 +244,7 @@ export default ListFormController.extend({
     '  componentName=\"SuggestionsObjectListView\"<br>' +
     '  content=model<br>' +
     '  modelName=\"ember-flexberry-dummy-suggestion\"<br>' +
-    '  editFormRoute=editFormRoute<br>' +
+    '  editFormRoute=\"ember-flexberry-dummy-suggestion\"<br>' +
     '  modelProjection=projection<br>' +
     '  placeholder=placeholder<br>' +
     '  readonly=readonly<br>' +
@@ -318,12 +318,6 @@ export default ListFormController.extend({
       settingValue: 'ember-flexberry-dummy-suggestion',
       settingDefaultValue: undefined,
       settingIsWithoutUI: true
-    });
-    componentSettingsMetadata.pushObject({
-      settingName: 'editFormRoute',
-      settingType: 'string',
-      settingDefaultValue: 'ember-flexberry-dummy-suggestion-edit',
-      bindedControllerPropertieName: 'editFormRoute'
     });
     componentSettingsMetadata.pushObject({
       settingName: 'placeholder',

--- a/tests/dummy/app/locales/en/translations.js
+++ b/tests/dummy/app/locales/en/translations.js
@@ -250,6 +250,10 @@ Ember.$.extend(true, translations, {
             'custom-filter': {
               'caption': 'Custom filter',
               'title': ''
+            },
+            'configurate-rows': {
+              'caption': 'Configurate rows',
+              'title': ''
             }
           },
           'flexberry-simpledatetime': {
@@ -522,6 +526,9 @@ Ember.$.extend(true, translations, {
         },
         'custom-filter': {
           'caption': 'Flexberry-objectlistview. Custom filter'
+        },
+        'configurate-rows': {
+          'caption': 'Flexberry-objectlistview. Configurate rows'
         }
       },
       'flexberry-simpledatetime': {

--- a/tests/dummy/app/locales/ru/translations.js
+++ b/tests/dummy/app/locales/ru/translations.js
@@ -253,6 +253,10 @@ Ember.$.extend(true, translations, {
             'custom-filter': {
               'caption': 'Настройка фильтра',
               'title': ''
+            },
+            'configurate-rows': {
+              'caption': 'Раскраска строк',
+              'title': ''
             }
           },
           'flexberry-simpledatetime': {
@@ -526,6 +530,9 @@ Ember.$.extend(true, translations, {
         },
         'custom-filter': {
           'caption': 'Flexberry-objectlistview. Настройка фильтра'
+        },
+        'configurate-rows': {
+          'caption': 'Flexberry-objectlistview. Раскраска строк'
         }
       },
       'flexberry-simpledatetime': {

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -55,6 +55,7 @@ Router.map(function() {
   this.route('components-examples/flexberry-objectlistview/on-edit-form');
   this.route('components-examples/flexberry-objectlistview/on-edit-form/user', { path: 'components-examples/flexberry-objectlistview/on-edit-form/user/:id' });
   this.route('components-examples/flexberry-objectlistview/custom-filter');
+  this.route('components-examples/flexberry-objectlistview/configurate-rows');
   this.route('components-examples/flexberry-simpledatetime/settings-example');
   this.route('components-examples/flexberry-textarea/settings-example');
   this.route('components-examples/flexberry-textbox/settings-example');

--- a/tests/dummy/app/routes/components-examples/flexberry-objectlistview/configurate-rows.js
+++ b/tests/dummy/app/routes/components-examples/flexberry-objectlistview/configurate-rows.js
@@ -1,0 +1,43 @@
+import ListFormRoute from 'ember-flexberry/routes/list-form';
+
+export default ListFormRoute.extend({
+  /**
+    Name of model projection to be used as record's properties limitation.
+
+    @property modelProjection
+    @type String
+    @default 'SuggestionL'
+   */
+  modelProjection: 'SuggestionL',
+
+  /**
+  developerUserSettings.
+  {
+  <componentName>: {
+    <settingName>: {
+        colsOrder: [ { propName :<colName>, hide: true|false }, ... ],
+        sorting: [{ propName: <colName>, direction: "asc"|"desc" }, ... ],
+        colsWidths: [ <colName>:<colWidth>, ... ],
+      },
+      ...
+    },
+    ...
+  }
+  For default userSetting use empty name ('').
+  <componentName> may contain any of properties: colsOrder, sorting, colsWidth or being empty.
+
+  @property developerUserSettings
+  @type Object
+  @default {}
+  */
+  developerUserSettings: { FOLVSettingExampleObjectListView: { } },
+
+  /**
+    Name of model to be used as list's records types.
+
+    @property modelName
+    @type String
+    @default 'ember-flexberry-dummy-suggestion'
+   */
+  modelName: 'ember-flexberry-dummy-suggestion'
+});

--- a/tests/dummy/app/templates/components-examples/flexberry-objectlistview/configurate-rows.hbs
+++ b/tests/dummy/app/templates/components-examples/flexberry-objectlistview/configurate-rows.hbs
@@ -1,0 +1,33 @@
+<h3 class="ui header">{{t "forms.components-examples.flexberry-objectlistview.configurate-rows.caption"}}</h3>
+<form class="ui form flexberry-vertical-form" role="form">
+  <div class="field">
+    {{#settings-example
+      controllerProperties=this
+      componentSettingsMetadata=componentSettingsMetadata
+      componentTemplateText=componentTemplateText
+    }}
+      {{flexberry-objectlistview
+        componentName="SuggestionsObjectListView"
+        content=model
+        modelName="ember-flexberry-dummy-suggestion"
+        editFormRoute='ember-flexberry-dummy-suggestion-edit'
+        modelProjection=projection
+        filterByAnyMatch=(action "filterByAnyMatch")
+        filterText=filter
+        sorting=computedSorting
+        sortByColumn=(action "sortByColumn")
+        addColumnToSorting=(action "addColumnToSorting")
+        pages=pages
+        perPageValue=perPageValue
+        perPageValues=perPageValues
+        hasPreviousPage=hasPreviousPage
+        hasNextPage=hasNextPage
+        previousPage=(action "previousPage")
+        gotoPage=(action "gotoPage")
+        nextPage=(action "nextPage")
+        configurateRow=(action "configurateRow")
+        componentName="FOLVSettingExampleObjectListView"
+        }}
+    {{/settings-example}}
+  </div>
+</form>

--- a/tests/dummy/app/templates/components-examples/flexberry-objectlistview/settings-example.hbs
+++ b/tests/dummy/app/templates/components-examples/flexberry-objectlistview/settings-example.hbs
@@ -44,7 +44,6 @@
         previousPage=(action "previousPage")
         gotoPage=(action "gotoPage")
         nextPage=(action "nextPage")
-        configurateRow=(action "configurateRow")
         componentName="FOLVSettingExampleObjectListView"
         }}
     {{/settings-example}}

--- a/tests/dummy/app/templates/components-examples/flexberry-objectlistview/settings-example.hbs
+++ b/tests/dummy/app/templates/components-examples/flexberry-objectlistview/settings-example.hbs
@@ -10,7 +10,7 @@
         componentName="SuggestionsObjectListView"
         content=model
         modelName="ember-flexberry-dummy-suggestion"
-        editFormRoute=editFormRoute
+        editFormRoute='ember-flexberry-dummy-suggestion-edit'
         modelProjection=projection
         placeholder=placeholder
         readonly=readonly


### PR DESCRIPTION
Example Configurate rows moved to a separate page. 	Remove unnecessary controller's properties on example for olv.