### PR TITLE
Create in offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 * Detect necessity reload `aggregator` model if it was `detail` model modified.
+* Transition to edit form route when record has an `id` and same time is new.
 
 ## [0.7.0-beta.13] - 2016-10-07
 ### Changed

--- a/addon/mixins/flexberry-groupedit-route.js
+++ b/addon/mixins/flexberry-groupedit-route.js
@@ -81,7 +81,6 @@ export default Ember.Mixin.create({
           record = modelToAdd;
         }
 
-        let recordId = record.get('id');
         _this.controller.set('modelNoRollBack', true);
 
         let flexberryDetailInteractionService = _this.get('flexberryDetailInteractionService');
@@ -92,15 +91,13 @@ export default Ember.Mixin.create({
         flexberryDetailInteractionService.pushValue(
           'modelCurrentAgregators', _this.controller.get('modelCurrentAgregators'), _this.controller.get('model'));
 
-        if (recordId) {
-          _this.transitionTo(editFormRoute, record.get('id'))
-          .then(function(newRoute) {
+        if (record.get('isNew')) {
+          let newModelPath = _this.newRoutePath(editFormRoute);
+          _this.transitionTo(newModelPath).then((newRoute) => {
             newRoute.controller.set('readonly', methodOptions.readonly);
           });
         } else {
-          let newModelPath = _this.newRoutePath(editFormRoute);
-          _this.transitionTo(newModelPath)
-          .then(function(newRoute) {
+          _this.transitionTo(editFormRoute, record.get('id')).then((newRoute) => {
             newRoute.controller.set('readonly', methodOptions.readonly);
           });
         }


### PR DESCRIPTION
Transition to `edit-form` route after create new `detail` in offline instead of `edit-form-new` route.
This is due to fact that offline adapter immediately generate `id`, and it is considered that record already exists.