### PR TITLE
Fix duplicate `caption` key in locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Fix hierarchy expand for `flexberry-objectlistview` on edit form.
 * Fix operation indication on edit form when new record added.
 
+### Breaking changes
+* Search localisation for models in `flexberry-objectlistview` and `flexberry-simpleolv` components:
+  * Before: `models.modelName.projections.projectionName.attributePath.caption`
+  * After: `models.modelName.projections.projectionName.attributePath.__caption__`
+  * There are several solutions:
+    * Carefully regenerate the application.
+    * Find and replace in `Visual Studio Code`, files to include: `locales/en/models, locales/ru/models`, find: `(^\s+)(caption)`, replace: `$1__$2__`.
+
 ## [0.9.0-beta.18] - 2017-09-13
 ### Added
 * Add `yield` block for `flexberry-dropdown` component.

--- a/addon/components/flexberry-simpleolv.js
+++ b/addon/components/flexberry-simpleolv.js
@@ -1582,9 +1582,9 @@ ErrorableControllerMixin, {
           mainModelName = descriptor.type;
         }
       });
-      key = 'models.' + mainModelName + '.projections.' + mainModelProjection.projectionName + '.' + nameRelationship + '.' + bindingPath + '.caption';
+      key = `models.${mainModelName}.projections.${mainModelProjection.projectionName}.${nameRelationship}.${bindingPath}.__caption__`;
     } else {
-      key = 'models.' + modelName + '.projections.' + projection.projectionName + '.' + bindingPath + '.caption';
+      key = `models.${modelName}.projections.${projection.projectionName}.${bindingPath}.__caption__`;
     }
 
     return key;

--- a/addon/components/object-list-view.js
+++ b/addon/components/object-list-view.js
@@ -1435,9 +1435,9 @@ export default FlexberryBaseComponent.extend(
           mainModelName = descriptor.type;
         }
       });
-      key = 'models.' + mainModelName + '.projections.' + mainModelProjection.projectionName + '.' + nameRelationship + '.' + bindingPath + '.caption';
+      key = `models.${mainModelName}.projections.${mainModelProjection.projectionName}.${nameRelationship}.${bindingPath}.__caption__`;
     } else {
-      key = 'models.' + modelName + '.projections.' + projection.projectionName + '.' + bindingPath + '.caption';
+      key = `models.${modelName}.projections.${projection.projectionName}.${bindingPath}.__caption__`;
     }
 
     return key;

--- a/addon/locales/en/translations.js
+++ b/addon/locales/en/translations.js
@@ -216,46 +216,46 @@ export default {
       'projections': {
         'ApplicationLogL': {
           'processId': {
-            'caption': 'URL'
+            __caption__: 'URL'
           },
           'timestamp':{
-            'caption': 'Time'
+            __caption__: 'Time'
           },
           'category':{
-            'caption': 'Category'
+            __caption__: 'Category'
           },
           'eventId':{
-            'caption': 'Event ID'
+            __caption__: 'Event ID'
           },
           'priority':{
-            'caption': 'Priority'
+            __caption__: 'Priority'
           },
           'severity':{
-            'caption': 'Severity'
+            __caption__: 'Severity'
           },
           'title':{
-            'caption': 'Title'
+            __caption__: 'Title'
           },
           'machineName':{
-            'caption': 'Server'
+            __caption__: 'Server'
           },
           'appDomainName':{
-            'caption': 'Browser'
+            __caption__: 'Browser'
           },
           'processName':{
-            'caption': 'Process name'
+            __caption__: 'Process name'
           },
           'threadName':{
-            'caption': 'ThreadName'
+            __caption__: 'ThreadName'
           },
           'win32ThreadId':{
-            'caption': 'Win32ThreadId',
+            __caption__: 'Win32ThreadId',
           },
           'message':{
-            'caption': 'Message'
+            __caption__: 'Message'
           },
           'formattedMessage':{
-            'caption': 'Formatted message'
+            __caption__: 'Formatted message'
           }
         }
       }
@@ -263,9 +263,9 @@ export default {
     'new-platform-flexberry-services-lock': {
       'projections': {
         'LockL': {
-          'lockKey': { 'caption': 'Key locked object' },
-          'userName': { 'caption': 'User locked object' },
-          'lockDate': { 'caption': 'Date lock' },
+          'lockKey': { __caption__: 'Key locked object' },
+          'userName': { __caption__: 'User locked object' },
+          'lockDate': { __caption__: 'Date lock' },
         },
       },
     },

--- a/addon/locales/ru/translations.js
+++ b/addon/locales/ru/translations.js
@@ -218,46 +218,46 @@ export default {
       'projections': {
         'ApplicationLogL': {
           'processId': {
-            'caption': 'URL'
+            __caption__: 'URL'
           },
           'timestamp':{
-            'caption': 'Время'
+            __caption__: 'Время'
           },
           'category':{
-            'caption': 'Категория'
+            __caption__: 'Категория'
           },
           'eventId':{
-            'caption': 'Идентификтатор события'
+            __caption__: 'Идентификтатор события'
           },
           'priority':{
-            'caption': 'Приоритет'
+            __caption__: 'Приоритет'
           },
           'severity':{
-            'caption': 'Значимость'
+            __caption__: 'Значимость'
           },
           'title':{
-            'caption': 'Заголовок'
+            __caption__: 'Заголовок'
           },
           'machineName':{
-            'caption': 'Сервер'
+            __caption__: 'Сервер'
           },
           'appDomainName':{
-            'caption': 'Браузер'
+            __caption__: 'Браузер'
           },
           'processName':{
-            'caption': 'Имя процесса'
+            __caption__: 'Имя процесса'
           },
           'threadName':{
-            'caption': 'Имя потока'
+            __caption__: 'Имя потока'
           },
           'win32ThreadId':{
-            'caption': 'Идентификатор потока',
+            __caption__: 'Идентификатор потока',
           },
           'message':{
-            'caption': 'Сообщение'
+            __caption__: 'Сообщение'
           },
           'formattedMessage':{
-            'caption': 'Форматированное сообщение'
+            __caption__: 'Форматированное сообщение'
           }
         }
       }
@@ -265,9 +265,9 @@ export default {
     'new-platform-flexberry-services-lock': {
       'projections': {
         'LockL': {
-          'lockKey': { 'caption': 'Ключ заблокированного объекта' },
-          'userName': { 'caption': 'Заблокировавший пользователь' },
-          'lockDate': { 'caption': 'Дата блокировки' },
+          'lockKey': { __caption__: 'Ключ заблокированного объекта' },
+          'userName': { __caption__: 'Заблокировавший пользователь' },
+          'lockDate': { __caption__: 'Дата блокировки' },
         },
       },
     },

--- a/addon/mixins/olv-toolbar-controller.js
+++ b/addon/mixins/olv-toolbar-controller.js
@@ -265,9 +265,9 @@ export default Ember.Mixin.create({
           mainModelName = descriptor.type;
         }
       });
-      key = 'models.' + mainModelName + '.projections.' + mainModelProjection.projectionName + '.' + nameRelationship + '.' + bindingPath + '.caption';
+      key = `models.${mainModelName}.projections.${mainModelProjection.projectionName}.${nameRelationship}.${bindingPath}.__caption__`;
     } else {
-      key = 'models.' + modelName + '.projections.' + projection.projectionName + '.' + bindingPath + '.caption';
+      key = `models.${modelName}.projections.${projection.projectionName}.${bindingPath}.__caption__`;
     }
 
     return key;

--- a/blueprints/flexberry-core/Locales.js
+++ b/blueprints/flexberry-core/Locales.js
@@ -124,7 +124,7 @@ var ModelLocales = (function (_super) {
                     }
                 }
                 hasManyAttrs = lodash.sortBy(hasManyAttrs, ["index"]);
-                hasManyAttrs.unshift(new SortedPair(-1, "        caption: '" + this.escapeValue(hasMany.caption) + "'", "        caption: '" + hasMany.name + "'"));
+                hasManyAttrs.unshift(new SortedPair(-1, "        __caption__: '" + this.escapeValue(hasMany.caption) + "'", "        __caption__: '" + hasMany.name + "'"));
                 var attrsStr_1 = lodash.map(hasManyAttrs, "str").join(",\n        ");
                 var attrsStrOtherLocales_1 = lodash.map(hasManyAttrs, "strOtherLocales").join(",\n        ");
                 projAttrs.push(new SortedPair(Number.MAX_VALUE, hasMany.name + ": {\n" + attrsStr_1 + "\n      }", hasMany.name + ": {\n" + attrsStrOtherLocales_1 + "\n      }"));
@@ -164,7 +164,7 @@ var ModelLocales = (function (_super) {
             indent.pop();
             var indentStr2 = indent.join("");
             hasManyAttrs = lodash.sortBy(hasManyAttrs, ["index"]);
-            hasManyAttrs.unshift(new SortedPair(-1, "caption: '" + this.escapeValue(detailHasMany.caption) + "'", "caption: '" + detailHasMany.name + "'"));
+            hasManyAttrs.unshift(new SortedPair(-1, "__caption__: '" + this.escapeValue(detailHasMany.caption) + "'", "__caption__: '" + detailHasMany.name + "'"));
             var attrsStr = lodash.map(hasManyAttrs, "str").join(",\n" + indentStr);
             var attrsStrOtherLocales = lodash.map(hasManyAttrs, "strOtherLocales").join(",\n" + indentStr);
             return new SortedPair(Number.MAX_VALUE, detailHasMany.name + ": {\n" + indentStr + attrsStr + "\n" + indentStr2 + "}", detailHasMany.name + ": {\n" + indentStr + attrsStrOtherLocales + "\n" + indentStr2 + "}");
@@ -196,7 +196,7 @@ var ModelLocales = (function (_super) {
         else {
             index = belongsToAttrs[0].index;
         }
-        belongsToAttrs.unshift(new SortedPair(-1, "caption: '" + this.escapeValue(belongsTo.caption) + "'", "caption: '" + belongsTo.name + "'"));
+        belongsToAttrs.unshift(new SortedPair(-1, "__caption__: '" + this.escapeValue(belongsTo.caption) + "'", "__caption__: '" + belongsTo.name + "'"));
         var attrsStr = lodash.map(belongsToAttrs, "str").join(",\n" + indentStr);
         var attrsStrOtherLocales = lodash.map(belongsToAttrs, "strOtherLocales").join(",\n" + indentStr);
         return new SortedPair(index, belongsTo.name + ": {\n" + indentStr + attrsStr + "\n" + indentStr2 + "}", belongsTo.name + ": {\n" + indentStr + attrsStrOtherLocales + "\n" + indentStr2 + "}");
@@ -209,7 +209,7 @@ var ModelLocales = (function (_super) {
         var indentStr = indent.join("");
         indent.pop();
         var indentStr2 = indent.join("");
-        return new SortedPair(attr.index, attr.name + ": {\n" + indentStr + "caption: '" + this.escapeValue(attr.caption) + "'\n" + indentStr2 + "}", attr.name + ": {\n" + indentStr + "caption: '" + attr.name + "'\n" + indentStr2 + "}");
+        return new SortedPair(attr.index, attr.name + ": {\n" + indentStr + "__caption__: '" + this.escapeValue(attr.caption) + "'\n" + indentStr2 + "}", attr.name + ": {\n" + indentStr + "__caption__: '" + attr.name + "'\n" + indentStr2 + "}");
     };
     return ModelLocales;
 }(Locales));

--- a/blueprints/flexberry-core/Locales.ts
+++ b/blueprints/flexberry-core/Locales.ts
@@ -135,7 +135,7 @@ export class ModelLocales extends Locales {
           }
         }
         hasManyAttrs = lodash.sortBy(hasManyAttrs, ["index"]);
-        hasManyAttrs.unshift(new SortedPair(-1, `        caption: '${this.escapeValue(hasMany.caption)}'`, `        caption: '${hasMany.name}'`));
+        hasManyAttrs.unshift(new SortedPair(-1, `        __caption__: '${this.escapeValue(hasMany.caption)}'`, `        __caption__: '${hasMany.name}'`));
         let attrsStr = lodash.map(hasManyAttrs, "str").join(",\n        ");
         let attrsStrOtherLocales = lodash.map(hasManyAttrs, "strOtherLocales").join(",\n        ");
         projAttrs.push(new SortedPair(Number.MAX_VALUE,
@@ -173,7 +173,7 @@ export class ModelLocales extends Locales {
       indent.pop();
       let indentStr2 = indent.join("");
       hasManyAttrs = lodash.sortBy(hasManyAttrs, ["index"]);
-      hasManyAttrs.unshift(new SortedPair(-1, `caption: '${this.escapeValue(detailHasMany.caption)}'`, `caption: '${detailHasMany.name}'`));
+      hasManyAttrs.unshift(new SortedPair(-1, `__caption__: '${this.escapeValue(detailHasMany.caption)}'`, `__caption__: '${detailHasMany.name}'`));
       let attrsStr = lodash.map(hasManyAttrs, "str").join(",\n" + indentStr);
       let attrsStrOtherLocales = lodash.map(hasManyAttrs, "strOtherLocales").join(",\n" + indentStr);
 
@@ -207,7 +207,7 @@ export class ModelLocales extends Locales {
     } else {
       index = belongsToAttrs[0].index;
     }
-    belongsToAttrs.unshift(new SortedPair(-1, `caption: '${this.escapeValue(belongsTo.caption)}'`, `caption: '${belongsTo.name}'`));
+    belongsToAttrs.unshift(new SortedPair(-1, `__caption__: '${this.escapeValue(belongsTo.caption)}'`, `__caption__: '${belongsTo.name}'`));
     let attrsStr = lodash.map(belongsToAttrs, "str").join(",\n" + indentStr);
     let attrsStrOtherLocales = lodash.map(belongsToAttrs, "strOtherLocales").join(",\n" + indentStr);
 
@@ -226,8 +226,8 @@ export class ModelLocales extends Locales {
     indent.pop();
     let indentStr2 = indent.join("");
     return new SortedPair(attr.index,
-      `${attr.name}: {\n${indentStr}caption: '${this.escapeValue(attr.caption)}'\n${indentStr2}}`,
-      `${attr.name}: {\n${indentStr}caption: '${attr.name}'\n${indentStr2}}`
+      `${attr.name}: {\n${indentStr}__caption__: '${this.escapeValue(attr.caption)}'\n${indentStr2}}`,
+      `${attr.name}: {\n${indentStr}__caption__: '${attr.name}'\n${indentStr2}}`
     );
   }
 

--- a/tests/dummy/app/locales/en/translations.js
+++ b/tests/dummy/app/locales/en/translations.js
@@ -10,85 +10,85 @@ Ember.$.extend(true, translations, {
       'projections': {
         'SuggestionL': {
           'address': {
-            'caption': 'Address'
+            __caption__: 'Address'
           },
           'text': {
-            'caption': 'Text'
+            __caption__: 'Text'
           },
           'date': {
-            'caption': 'Date'
+            __caption__: 'Date'
           },
           'votes': {
-            'caption': 'Votes'
+            __caption__: 'Votes'
           },
           'author': {
-            'caption': 'Author',
+            __caption__: 'Author',
             'eMail': {
-              'caption': 'Email'
+              __caption__: 'Email'
             }
           },
           'editor1': {
-            'caption': 'Editor',
+            __caption__: 'Editor',
             'eMail': {
-              'caption': 'Email'
+              __caption__: 'Email'
             }
           },
           'moderated': {
-            'caption': 'Moderated'
+            __caption__: 'Moderated'
           },
           'type': {
-            'caption': 'Type'
+            __caption__: 'Type'
           },
           'commentsCount': {
-            'caption': 'Comments count'
+            __caption__: 'Comments count'
           },
           'comments': {
-            'caption': 'Comments'
+            __caption__: 'Comments'
           },
         },
         'SuggestionE': {
           'address': {
-            'caption': 'Address'
+            __caption__: 'Address'
           },
           'userVotes': {
             'name': {
-              'caption': 'Name'
+              __caption__: 'Name'
             },
             'voteType': {
-              'caption': 'Vote type'
+              __caption__: 'Vote type'
             },
             'author': {
-              'caption': 'Application User',
+              __caption__: 'Application User',
               'eMail': {
-                'caption': 'Email'
+                __caption__: 'Email'
               }
             }
           },
           'files': {
             'order': {
-              'caption': 'Order'
+              __caption__: 'Order'
             },
             'file': {
-              'caption': 'File',
+              __caption__: 'File',
             }
           },
           'comments': {
             'name': {
-              'caption': 'Name'
+              __caption__: 'Name'
             },
             'text': {
-              'caption': 'Text'
+              __caption__: 'Text'
             },
             'votes': {
-              'caption': 'Votes',
+              __caption__: 'Votes',
             },
             'moderated': {
-              'caption': 'Moderated',
+              __caption__: 'Moderated',
             },
             'author': {
-              'caption': 'Application User',
+              __caption__: 'Application User',
               'eMail': {
-                'caption': 'Mail'
+                __caption__: 'Mail'
               }
             }
           }
@@ -99,22 +99,22 @@ Ember.$.extend(true, translations, {
       'projections': {
         'ApplicationUserL': {
           'name': {
-            'caption': 'Name'
+            __caption__: 'Name'
           },
           'eMail': {
-            'caption': 'E-mail'
+            __caption__: 'E-mail'
           },
           'activated': {
-            'caption': 'Activated'
+            __caption__: 'Activated'
           },
           'birthday': {
-            'caption': 'Birthday'
+            __caption__: 'Birthday'
           },
           'gender': {
-            'caption': 'Gender'
+            __caption__: 'Gender'
           },
           'karma': {
-            'caption': 'Karma'
+            __caption__: 'Karma'
           },
         },
       }
@@ -123,7 +123,7 @@ Ember.$.extend(true, translations, {
       'projections': {
         'LocalizationL': {
           'name': {
-            'caption': 'Name'
+            __caption__: 'Name'
           },
         },
       }
@@ -132,27 +132,27 @@ Ember.$.extend(true, translations, {
       'projections': {
         'SuggestionTypeL': {
           'name': {
-            'caption': 'Name'
+            __caption__: 'Name'
           },
           'moderated': {
-            'caption': 'Moderated'
+            __caption__: 'Moderated'
           },
           'parent': {
-            'caption': 'Parent'
+            __caption__: 'Parent'
           },
         },
         'SuggestionTypeE': {
           'name': {
-            'caption': 'Name'
+            __caption__: 'Name'
           },
           'localizedTypes': {
             'name': {
-              'caption': 'Name'
+              __caption__: 'Name'
             },
             'localization': {
-              'caption': 'Localization',
+              __caption__: 'Localization',
               'name': {
-                'caption': 'Name'
+                __caption__: 'Name'
               }
             }
           },

--- a/tests/dummy/app/locales/ru/translations.js
+++ b/tests/dummy/app/locales/ru/translations.js
@@ -10,85 +10,85 @@ Ember.$.extend(true, translations, {
       'projections': {
         'SuggestionL': {
           'address': {
-            'caption': 'Адрес'
+            __caption__: 'Адрес'
           },
           'text': {
-            'caption': 'Текст'
+            __caption__: 'Текст'
           },
           'date': {
-            'caption': 'Дата'
+            __caption__: 'Дата'
           },
           'votes': {
-            'caption': 'Голоса'
+            __caption__: 'Голоса'
           },
           'author': {
-            'caption': 'Автор',
+            __caption__: 'Автор',
             'eMail': {
-              'caption': 'Почта'
+              __caption__: 'Почта'
             }
           },
           'editor1': {
-            'caption': 'Редактор',
+            __caption__: 'Редактор',
             'eMail': {
-              'caption': 'Почта'
+              __caption__: 'Почта'
             }
           },
           'moderated': {
-            'caption': 'Одобрено'
+            __caption__: 'Одобрено'
           },
           'type': {
-            'caption': 'Тип предложения'
+            __caption__: 'Тип предложения'
           },
           'commentsCount': {
-            'caption': 'Количество комментариев'
+            __caption__: 'Количество комментариев'
           },
           'comments': {
-            'caption': 'Комментарии'
+            __caption__: 'Комментарии'
           },
         },
         'SuggestionE': {
           'address': {
-            'caption': 'Адрес'
+            __caption__: 'Адрес'
           },
           'userVotes': {
             'name': {
-              'caption': 'Наименование'
+              __caption__: 'Наименование'
             },
             'voteType': {
-              'caption': 'Тип голосования'
+              __caption__: 'Тип голосования'
             },
             'author': {
-              'caption': 'Пользователь приложения',
+              __caption__: 'Пользователь приложения',
               'eMail': {
-                'caption': 'Почта'
+                __caption__: 'Почта'
               }
             }
           },
           'files': {
             'order': {
-              'caption': 'Номер'
+              __caption__: 'Номер'
             },
             'file': {
-              'caption': 'Файл',
+              __caption__: 'Файл',
             }
           },
           'comments': {
             'name': {
-              'caption': 'Наименование'
+              __caption__: 'Наименование'
             },
             'text': {
-              'caption': 'Текст'
+              __caption__: 'Текст'
             },
             'votes': {
-              'caption': 'Голоса',
+              __caption__: 'Голоса',
             },
             'moderated': {
-              'caption': 'Одобрено',
+              __caption__: 'Одобрено',
             },
             'author': {
-              'caption': 'Пользователь приложения',
+              __caption__: 'Пользователь приложения',
               'eMail': {
-                'caption': 'Почта'
+                __caption__: 'Почта'
               }
             }
           }
@@ -99,22 +99,22 @@ Ember.$.extend(true, translations, {
       'projections': {
         'ApplicationUserL': {
           'name': {
-            'caption': 'Имя'
+            __caption__: 'Имя'
           },
           'eMail': {
-            'caption': 'Почта'
+            __caption__: 'Почта'
           },
           'activated': {
-            'caption': 'Учетная запись активирована'
+            __caption__: 'Учетная запись активирована'
           },
           'birthday': {
-            'caption': 'Дата рождения'
+            __caption__: 'Дата рождения'
           },
           'gender': {
-            'caption': 'Пол'
+            __caption__: 'Пол'
           },
           'karma': {
-            'caption': 'Карма'
+            __caption__: 'Карма'
           },
         },
       }
@@ -123,7 +123,7 @@ Ember.$.extend(true, translations, {
       'projections': {
         'LocalizationL': {
           'name': {
-            'caption': 'Наименование'
+            __caption__: 'Наименование'
           },
         },
       }
@@ -132,24 +132,24 @@ Ember.$.extend(true, translations, {
       'projections': {
         'SuggestionTypeL': {
           'name': {
-            'caption': 'Наименование'
+            __caption__: 'Наименование'
           },
           'moderated': {
-            'caption': 'Одобрено'
+            __caption__: 'Одобрено'
           },
           'parent': {
-            'caption': 'Иерархия'
+            __caption__: 'Иерархия'
           },
         },
         'SuggestionTypeE': {
           'localizedTypes': {
             'name': {
-              'caption': 'Наименование'
+              __caption__: 'Наименование'
             },
             'localization': {
-              'caption': 'Локализация',
+              __caption__: 'Локализация',
               'name': {
-                'caption': 'Наименование'
+                __caption__: 'Наименование'
               }
             }
           },
@@ -160,16 +160,16 @@ Ember.$.extend(true, translations, {
       'projections': {
         'CommentE': {
           'text': {
-            'caption': 'Текст комментария'
+            __caption__: 'Текст комментария'
           },
           'userVotes': {
             'voteType': {
-              'caption': 'Тип голосования'
+              __caption__: 'Тип голосования'
             },
             'applicationUser': {
-              'caption': 'Пользователь',
+              __caption__: 'Пользователь',
               'name': {
-                'caption': 'Наименование'
+                __caption__: 'Наименование'
               }
             }
           },


### PR DESCRIPTION
When generate models with `caption` attributes, locales can contains `caption` duplicate key.
[#152170](http://dis-tfs:8080/Common/CASEBERRY/_workitems/edit/152170)