### PR TITLE
Add asynchronous mode support for `beforeDeleteRecord`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.2-beta.01] - 2017-10-03
+### Changed
+* List components:
+    * `beforeDeleteRecord` method now support asynchronous mode, i.e. it is possible to return promises as result value.
+
 ## [0.9.1] - 2017-09-29
 ### Changed
 * Update dependency on `ember-flexberry-data` to version 0.9.0.

--- a/addon/components/flexberry-simpleolv.js
+++ b/addon/components/flexberry-simpleolv.js
@@ -2014,7 +2014,7 @@ ErrorableControllerMixin, {
     if (possiblePromise || (possiblePromise instanceof Ember.RSVP.Promise)) {
       possiblePromise.then(() => {
         if (!data.cancel) {
-         this._actualDeleteRecord(record, data.immediately);
+          this._actualDeleteRecord(record, data.immediately);
         }
       });
     } else {

--- a/addon/components/object-list-view.js
+++ b/addon/components/object-list-view.js
@@ -1898,20 +1898,44 @@ export default FlexberryBaseComponent.extend(
   */
   _deleteRecord(record, immediately) {
     let beforeDeleteRecord = this.get('beforeDeleteRecord');
+    let possiblePromise = null;
+    let data = {
+      immediately: immediately,
+      cancel: false
+    };
+
     if (beforeDeleteRecord) {
       Ember.assert('beforeDeleteRecord must be a function', typeof beforeDeleteRecord === 'function');
 
-      let data = {
-        immediately: immediately,
-        cancel: false
-      };
-      beforeDeleteRecord(record, data);
+      possiblePromise = beforeDeleteRecord(record, data);
 
-      if (data.cancel) {
+      if ((!possiblePromise || !(possiblePromise instanceof Ember.RSVP.Promise)) && data.cancel) {
         return;
       }
     }
 
+    if (possiblePromise || (possiblePromise instanceof Ember.RSVP.Promise)) {
+      possiblePromise.then(() => {
+        if (!data.cancel) {
+         this._actualDeleteRecord(record, data.immediately);
+        }
+      });
+    } else {
+      this._actualDeleteRecord(record, data.immediately);
+    }
+  },
+
+  /**
+    Actually delete the record.
+
+    @method _actualDeleteRecord
+    @private
+
+    @param {DS.Model} record A record to delete
+    @param {Boolean} immediately If `true`, relationships have been destroyed (delete and save)
+  */
+
+  _actualDeleteRecord(record, immediately) {
     let key = this._getModelKey(record);
     this._removeModelWithKey(key);
 

--- a/addon/components/object-list-view.js
+++ b/addon/components/object-list-view.js
@@ -1917,7 +1917,7 @@ export default FlexberryBaseComponent.extend(
     if (possiblePromise || (possiblePromise instanceof Ember.RSVP.Promise)) {
       possiblePromise.then(() => {
         if (!data.cancel) {
-         this._actualDeleteRecord(record, data.immediately);
+          this._actualDeleteRecord(record, data.immediately);
         }
       });
     } else {


### PR DESCRIPTION
`beforeDeleteRecord` method in list components now support asynchronous mode, i.e. it is possible to return promises as result value.