### PR TITLE
Add maxlength attribute for flexberry-textbox.

### DIFF
--- a/app/templates/components/flexberry-field.hbs
+++ b/app/templates/components/flexberry-field.hbs
@@ -7,4 +7,5 @@
   readonly=(if readonly "readonly")
   required=required
   placeholder=placeholder
+  maxlength=maxlength
 }}

--- a/app/templates/components/flexberry-textbox.hbs
+++ b/app/templates/components/flexberry-textbox.hbs
@@ -5,6 +5,7 @@
     readonly="readonly"
     required=required
     placeholder=placeholder
+    maxlength=maxlength
   }}
 {{else}}
   {{input
@@ -12,5 +13,6 @@
     value=value
     required=required
     placeholder=placeholder
+    maxlength=maxlength
   }}
 {{/if}}

--- a/tests/integration/components/flexberry-field-test.js
+++ b/tests/integration/components/flexberry-field-test.js
@@ -352,6 +352,25 @@ test('changes in inner <input> causes changes in property binded to \'value\'', 
     'Component\'s property binded to \'value\' is equals to \'' + newValue + '\'');
 });
 
+test('attribute maxlength rendered in html', function(assert) {
+  assert.expect(1);
+
+  // Render component.
+  this.render(hbs`{{flexberry-field
+    maxlength=5
+  }}`);
+
+  // Retrieve component.
+  let $component = this.$().children();
+  let $fieldInput = Ember.$('.flexberry-textbox input', $component);
+
+  // Check <input>'s maxlength attribute.
+  assert.strictEqual(
+    $fieldInput.attr('maxlength'),
+    '5',
+    'Component\'s inner <input>\'s attribute maxlength rendered');
+});
+
 test('changes in property binded to \'value\' causes changes in inner <input>', function(assert) {
   assert.expect(4);
 

--- a/tests/integration/components/flexberry-textbox-test.js
+++ b/tests/integration/components/flexberry-textbox-test.js
@@ -296,6 +296,25 @@ test('changes in inner <input> causes changes in property binded to \'value\'', 
     'Component\'s property binded to \'value\' is equals to \'' + newValue + '\'');
 });
 
+test('attribute maxlength rendered in html', function(assert) {
+  assert.expect(1);
+
+  // Render component.
+  this.render(hbs`{{flexberry-field
+    maxlength=5
+  }}`);
+
+  // Retrieve component.
+  let $component = this.$().children();
+  let $fieldInput = Ember.$('.flexberry-textbox input', $component);
+
+  // Check <input>'s maxlength attribute.
+  assert.strictEqual(
+    $fieldInput.attr('maxlength'),
+    '5',
+    'Component\'s inner <input>\'s attribute maxlength rendered');
+});
+
 test('changes in property binded to \'value\' causes changes in inner <input>', function(assert) {
   assert.expect(4);
 


### PR DESCRIPTION
Made an optional attribute available to limit the maximum length of the string entered into the flexberry-textbox component.