### PR TITLE
Fix inability to choose extreme values of date range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     * Buttons in rows when the component is in hierarchical mode.
     * Fix `singleColumnHeaderTitle` at mobile.
     * After disable hierarchical mode in mobile, button for show/hide nested records remains.
+* `flexberry-simpledatetime` component:
+    * Inability to choose extreme values of date range when min or max values are set.
 * Displaying spinner when appying user settings using user settings dialog.
 
 ## [0.11.1-beta.1] - 2018-03-07

--- a/addon/components/flexberry-simpledatetime.js
+++ b/addon/components/flexberry-simpledatetime.js
@@ -152,12 +152,13 @@ export default FlexberryBaseComponent.extend({
       return this.get('_minAsString');
     },
     set(key, value) {
+      let minValue = value instanceof Date ? value.setMilliseconds(0) : moment(value).toDate().setMilliseconds(0);
       if (this.get('useBrowserInput') && this.get('currentTypeSupported')) {
-        this.set('_minAsString', this._convertDateToString(value));
+        this.set('_minAsString', this._convertDateToString(minValue));
       } else {
         let flatpickr = this.get('_flatpickr');
         if (flatpickr) {
-          flatpickr.set('minDate', value);
+          flatpickr.set('minDate', minValue);
         }
       }
 
@@ -176,12 +177,13 @@ export default FlexberryBaseComponent.extend({
       return this.get('_maxAsString');
     },
     set(key, value) {
+      let maxValue = value instanceof Date ? value.setMilliseconds(0) : moment(value).toDate().setMilliseconds(0);
       if (this.get('useBrowserInput') && this.get('currentTypeSupported')) {
-        this.set('_maxAsString', this._convertDateToString(value));
+        this.set('_maxAsString', this._convertDateToString(maxValue));
       } else {
         let flatpickr = this.get('_flatpickr');
         if (flatpickr) {
-          flatpickr.set('maxDate', value);
+          flatpickr.set('maxDate', maxValue);
         }
       }
 

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "blob-polyfill": "~1.0.20150320",
     "devicejs": "0.2.7",
     "blueimp-file-upload": "9.11.2",
-    "flatpickr-calendar": "2.3.4",
+    "flatpickr-calendar": "2.6.3",
     "seiyria-bootstrap-slider": "6.0.6",
     "jquery-minicolors": "2.2.6",
     "js-beautify": "1.6.4"

--- a/tests/dummy/app/controllers/ember-flexberry-dummy-suggestion-edit.js
+++ b/tests/dummy/app/controllers/ember-flexberry-dummy-suggestion-edit.js
@@ -63,9 +63,9 @@ export default BaseEditFormController.extend(EditFormControllerOperationsIndicat
     } else if (attr.kind === 'attr') {
       switch (`${model.modelName}+${bindingPath}`) {
         case 'ember-flexberry-dummy-vote+author.eMail':
-        cellComponent.componentProperties = {
-          readonly: true,
-        };
+          cellComponent.componentProperties = {
+            readonly: true,
+          };
       }
     }
 


### PR DESCRIPTION
Fix inability to choose extreme values of date range for `flexberry-simpledatetime` when min or max values are set