### PR TITLE
Fix error when moving row in flexberry-groupedit component

### DIFF
--- a/addon/components/object-list-view.js
+++ b/addon/components/object-list-view.js
@@ -2694,7 +2694,7 @@ export default FlexberryBaseComponent.extend(
           content[indexRecord].set(`${orderedProperty}`, orderValueAbove);
           content[newIndex].set(`${orderedProperty}`, orderValue);
 
-          let temp = contentForRender[indexRecord];
+          let temp = [contentForRender[indexRecord]];
           contentForRender.replace(indexRecord, 1);
           contentForRender.replace(newIndex, 0, temp);
         }


### PR DESCRIPTION
This fix is valid for versions `2.x` and `3.x`.
Fix #790.