### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * `olv-toolbar` component:
     * Fix styles of `export excel` and `cols config` buttons.
 
+### Changed
+* Update dependency on the `jquery-minicolors` bower package to version `2.3.4`.
+
 ## [2.2.0-beta.17] - 2019-11-13
 ### Fixed
 * `flexberry-lookup` component:

--- a/blueprints/ember-flexberry/index.js
+++ b/blueprints/ember-flexberry/index.js
@@ -241,7 +241,7 @@ module.exports = {
         { name: 'blueimp-file-upload', target: '9.11.2' },
         { name: 'devicejs', target: '0.2.7' },
         { name: 'seiyria-bootstrap-slider', target: '6.0.6' },
-        { name: 'jquery-minicolors', target: '2.2.6' },
+        { name: 'jquery-minicolors', target: '2.3.4' },
         { name: 'js-beautify', target: '1.6.4' }
       ]);
     }).then(function() {

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "blueimp-file-upload": "9.11.2",
     "flatpickr-calendar": "2.6.3",
     "seiyria-bootstrap-slider": "6.0.6",
-    "jquery-minicolors": "2.2.6",
+    "jquery-minicolors": "2.3.4",
     "js-beautify": "1.6.4"
   },
   "resolutions": {


### PR DESCRIPTION
The `jquery-minicolors` bower package from `2.2.6` to `2.3.4` versoin.