### PR TITLE
Fix state of the move buttons in flexberry-groupedit component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+* The state of the move buttons in the `flexberry-groupedit` now depends on the selected rows.
 
 ## [2.2.1] - 2020-01-15
 ### Added

--- a/addon/components/groupedit-toolbar.js
+++ b/addon/components/groupedit-toolbar.js
@@ -22,15 +22,12 @@ export default FlexberryBaseComponent.extend({
   _groupEditEventsService: Ember.inject.service('objectlistview-events'),
 
   /**
-    Boolean flag to indicate enabled state of delete rows button.
-
-    If rows at {{#crossLink "FlexberryGroupeditComponent"}}{{/crossLink}} are selected this flag is enabled.
-
-    @property _isDeleteRowsEnabled
-    @type Boolean
     @private
+    @property _hasSelectedRows
+    @type Boolean
+    @default false
   */
-  _isDeleteRowsEnabled: undefined,
+  _hasSelectedRows: false,
 
   /**
     @private
@@ -263,7 +260,7 @@ export default FlexberryBaseComponent.extend({
   */
   _rowSelected(componentName, record, count, checked, recordWithKey) {
     if (componentName === this.get('componentName')) {
-      this.set('_isDeleteRowsEnabled', count > 0);
+      this.set('_hasSelectedRows', count > 0);
 
       const $tbody = this.$().parent().find('tbody');
       const $tr = $tbody.find('tr.active');
@@ -284,7 +281,7 @@ export default FlexberryBaseComponent.extend({
   */
   _rowsDeleted(componentName, count) {
     if (componentName === this.get('componentName')) {
-      this.set('_isDeleteRowsEnabled', false);
+      this.set('_hasSelectedRows', false);
     }
   }
 });

--- a/addon/components/groupedit-toolbar.js
+++ b/addon/components/groupedit-toolbar.js
@@ -33,6 +33,22 @@ export default FlexberryBaseComponent.extend({
   _isDeleteRowsEnabled: undefined,
 
   /**
+    @private
+    @property _disableMoveUpButton
+    @type Boolean
+    @default false
+  */
+  _disableMoveUpButton: false,
+
+  /**
+    @private
+    @property _disableMoveDownButton
+    @type Boolean
+    @default false
+  */
+  _disableMoveDownButton: false,
+
+  /**
     Default class for component wrapper.
 
     @property classNames
@@ -248,6 +264,12 @@ export default FlexberryBaseComponent.extend({
   _rowSelected(componentName, record, count, checked, recordWithKey) {
     if (componentName === this.get('componentName')) {
       this.set('_isDeleteRowsEnabled', count > 0);
+
+      const $tbody = this.$().parent().find('tbody');
+      const $tr = $tbody.find('tr.active');
+
+      this.set('_disableMoveUpButton', $tr.first().get(0) === $tbody.get(0).firstElementChild);
+      this.set('_disableMoveDownButton', $tr.last().get(0) === $tbody.get(0).lastElementChild);
     }
   },
 

--- a/app/templates/components/groupedit-toolbar.hbs
+++ b/app/templates/components/groupedit-toolbar.hbs
@@ -8,9 +8,9 @@
 {{/if}}
 {{#if deleteButton}}
   <button
-    class="ui ui-delete {{if _isDeleteRowsEnabled '' 'disabled'}} {{buttonClass}} button"
+    class="ui ui-delete {{unless _hasSelectedRows "disabled"}} {{buttonClass}} button"
     title={{t "components.groupedit-toolbar.delete-button-text"}}
-    disabled={{readonly}} {{action 'deleteRows'}}>
+    disabled={{or (not _hasSelectedRows) readonly}} {{action 'deleteRows'}}>
       <i class="minus icon"></i>
   </button>
 {{/if}}
@@ -27,7 +27,7 @@
   <button
     class="ui ui-move-up {{buttonClass}} button"
     title={{t "components.groupedit-toolbar.move-up-button-text"}}
-    disabled={{or _disableMoveUpButton readonly}}
+    disabled={{or (not _hasSelectedRows) _disableMoveUpButton readonly}}
     {{action 'moveRow' -1}}>
       <i class="arrow up icon"></i>
   </button>
@@ -35,7 +35,7 @@
   <button
     class="ui ui-move-down {{buttonClass}} button"
     title={{t "components.groupedit-toolbar.move-down-button-text"}}
-    disabled={{or _disableMoveDownButton readonly}}
+    disabled={{or (not _hasSelectedRows) _disableMoveDownButton readonly}}
     {{action 'moveRow' 1}}>
       <i class="arrow down icon"></i>
   </button>

--- a/app/templates/components/groupedit-toolbar.hbs
+++ b/app/templates/components/groupedit-toolbar.hbs
@@ -27,7 +27,7 @@
   <button
     class="ui ui-move-up {{buttonClass}} button"
     title={{t "components.groupedit-toolbar.move-up-button-text"}}
-    disabled={{readonly}}
+    disabled={{or _disableMoveUpButton readonly}}
     {{action 'moveRow' -1}}>
       <i class="arrow up icon"></i>
   </button>
@@ -35,7 +35,7 @@
   <button
     class="ui ui-move-down {{buttonClass}} button"
     title={{t "components.groupedit-toolbar.move-down-button-text"}}
-    disabled={{readonly}}
+    disabled={{or _disableMoveDownButton readonly}}
     {{action 'moveRow' 1}}>
       <i class="arrow down icon"></i>
   </button>

--- a/tests/acceptance/edit-form-validation-test/validation-detail-delete-test.js
+++ b/tests/acceptance/edit-form-validation-test/validation-detail-delete-test.js
@@ -20,10 +20,8 @@ executeTest('check detail delete', (store, assert, app) => {
     let $validationFlexberryOLVDeleteButton = Ember.$(Ember.$('.ui.disabled.button')[1]);
 
     // Delete detail.
-    Ember.run(() => {
-      $validationFlexberryCheckbox.click();
-      $validationFlexberryOLVDeleteButton.click();
-    });
+    Ember.run($validationFlexberryCheckbox, $validationFlexberryCheckbox.click);
+    Ember.run($validationFlexberryOLVDeleteButton, $validationFlexberryOLVDeleteButton.click);
 
     // Сounting the number of validationmessage = 8 afther detail delete.
     $validationLablesContainer = Ember.$('.ember-view.ui.basic.label');


### PR DESCRIPTION
The buttons for moving rows in the `flexberry-groupedit` component were always active, regardless of the presence of selected rows in the component.