### PR TITLE
Fix error accessing an DOM element when a component is destroying

### DIFF
--- a/addon/components/groupedit-toolbar.js
+++ b/addon/components/groupedit-toolbar.js
@@ -259,7 +259,7 @@ export default FlexberryBaseComponent.extend({
     @param {Object} recordWithKey The model wrapper with additional key corresponding to selected row
   */
   _rowSelected(componentName, record, count, checked, recordWithKey) {
-    if (componentName === this.get('componentName')) {
+    if (componentName === this.get('componentName') && !this.get('isDestroying')) {
       this.set('_hasSelectedRows', count > 0);
 
       const $tbody = this.$().parent().find('tbody');


### PR DESCRIPTION
The `_rowSelected` trigger fires when an item is removed from the DOM, possibly because the selected records are updated in the `didRender` hook of the `object-list-view` component.