### PR TITLE
Closes #1266, added actualization of error list on flexberry-validationsummary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+* Support of `errors` property change for `flexberry-validationsummary`.
 
 ## [2.6.0-beta.10] - 2021-04-22
 ### Changed

--- a/tests/integration/components/flexberry-validationsummary-test.js
+++ b/tests/integration/components/flexberry-validationsummary-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Errors from 'ember-validations/errors';
+import Ember from 'ember';
 
 moduleForComponent('flexberry-validationsummary', 'Integration | Component | flexberry validationsummary', {
   integration: true
@@ -55,4 +56,28 @@ test('it should be visible if errors presence', function (assert) {
 
   this.render(hbs`{{flexberry-validationsummary errors=errors}}`);
   assert.equal(this.$(':first-child').is(':visible'), true);
+});
+
+test('it renders changing error list', function (assert) {
+  let errors = Errors.create();
+  errors.set('testProperty', ['error1']);
+  this.set('errors', errors);
+
+  // Initialize by errors property.
+  this.render(hbs`{{flexberry-validationsummary errors=errors}}`);
+  assert.equal(this.$().text().trim(), 'error1');
+
+  Ember.run(() => {
+    // Now change errors property, component should also change it's view.
+    errors.set('testProperty', ['error11', 'error12']);
+  });
+
+  assert.equal(this.$().text().replace(/\n|\s/g, ""), 'error11error12');
+
+  Ember.run(() => {
+    // Now add errors property, component should also change it's view.
+    errors.set('testProperty2', ['error2']);
+  });
+  
+  assert.equal(this.$().text().replace(/\n|\s/g, ""), 'error11error12error2');
 });

--- a/tests/integration/components/flexberry-validationsummary-test.js
+++ b/tests/integration/components/flexberry-validationsummary-test.js
@@ -60,24 +60,50 @@ test('it should be visible if errors presence', function (assert) {
 
 test('it renders changing error list', function (assert) {
   let errors = Errors.create();
-  errors.set('testProperty', ['error1']);
-  this.set('errors', errors);
+  Ember.set(errors, 'testProperty', ['error1']);
+  Ember.set(this, 'errors', errors);
 
   // Initialize by errors property.
   this.render(hbs`{{flexberry-validationsummary errors=errors}}`);
   assert.equal(this.$().text().trim(), 'error1');
 
+  let testPropertyErrorList = new Ember.A(['error11', 'error12']);
   Ember.run(() => {
-    // Now change errors property, component should also change it's view.
-    errors.set('testProperty', ['error11', 'error12']);
+    // Change existing errors property.
+    Ember.set(errors, 'testProperty', testPropertyErrorList);
   });
 
   assert.equal(this.$().text().replace(/\n|\s/g, ""), 'error11error12');
 
   Ember.run(() => {
-    // Now add errors property, component should also change it's view.
-    errors.set('testProperty2', ['error2']);
+    // Add new errors property.
+    Ember.set(errors, 'testProperty2', ['error2']);
   });
   
   assert.equal(this.$().text().replace(/\n|\s/g, ""), 'error11error12error2');
+
+  Ember.run(() => {
+    // Remove element from existing errors property.
+    Ember.get(errors, 'testProperty').popObject();
+  });
+
+  assert.equal(this.$().text().replace(/\n|\s/g, ""), 'error11error2');
+
+  Ember.run(() => {
+    // Add element to existing errors property.
+    Ember.get(errors, 'testProperty').pushObject('error13');
+  });
+
+  assert.equal(this.$().text().replace(/\n|\s/g, ""), 'error11error13error2');
+
+  let errors2 = Errors.create();
+  Ember.set(errors2, 'testProperty2', ['error22']);
+  Ember.set(errors2, 'testProperty3', ['error3']);
+
+  Ember.run(() => {
+    // Change errors object.
+    Ember.set(this, 'errors', errors2);
+  });
+
+  assert.equal(this.$().text().replace(/\n|\s/g, ""), 'error22error3');
 });


### PR DESCRIPTION
This revision is needed only for ember-flexberry 2.x (there is another external validation component for 3.x and observers are not needed).
It removes observers and adds computed properties instead.
It observes changes on errors property change (earlier properties of errors object were fixed on component init and adding new property was not supported).

But there is also one side-effect. This revision displays in flexberry-validationsummary errors on details on edit form too.