### PR TITLE
Added opportunity to set autocomplete window direction for lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+* Property `autocompleteDirection` for `flexberry-lookup` to set direction of autocomplete window.
 
 ## [2.6.0-beta.11] - 2021-05-14
 ### Added

--- a/addon/components/flexberry-lookup.js
+++ b/addon/components/flexberry-lookup.js
@@ -620,6 +620,16 @@ export default FlexberryBaseComponent.extend({
   autocompleteOrder: null,
 
   /**
+    Direction of list for autocomplete values.
+    Availible values: 'upward', 'downward', 'auto'.
+
+    @property autocompleteDirection
+    @type String
+    @default downward
+  */
+  autocompleteDirection: 'downward',
+
+  /**
     Projection name for autocomplete query.
 
     @property autocompleteProjection
@@ -1157,7 +1167,7 @@ export default FlexberryBaseComponent.extend({
 
       /**
        * Handles opening of the autocomplete list.
-       * Sets current state (taht autocomplete list is opened) for future purposes.
+       * Sets current state (that autocomplete list is opened).
        */
       onResultsOpen() {
         state = 'opened';
@@ -1165,6 +1175,22 @@ export default FlexberryBaseComponent.extend({
         Ember.run(() => {
           Ember.debug(`Flexberry Lookup::autocomplete state = ${state}`);
         });
+
+        let autocompleteDirection = Ember.get(_this, 'autocompleteDirection');
+        if (autocompleteDirection == 'auto')
+        {
+          const { height, left, width, bottom } = _this.element.getBoundingClientRect();
+          let elementHeight = _this.$('div.results').outerHeight();
+          let upward = window.innerHeight - bottom < elementHeight;
+          autocompleteDirection = upward ? 'upward' : 'downward';
+        }
+
+        if (autocompleteDirection == 'upward') {
+          _this.$('div.results').addClass('upward');
+        }
+        else {
+          _this.$('div.results').removeClass('upward');
+        }
       },
 
       /**

--- a/addon/styles/themes/blue-sky/collections/form.overrides
+++ b/addon/styles/themes/blue-sky/collections/form.overrides
@@ -37,6 +37,11 @@
     outline: none;
 }
 
+.flexberry-lookup div.results.upward {
+    top: auto;
+    bottom: 100%;
+}
+
 .flexberry-simpledatetime .ui.fluid.action.input {
     border: none;
     border-bottom: 1px solid @inputBorderColor;

--- a/tests/dummy/app/controllers/components-examples/flexberry-lookup/settings-example.js
+++ b/tests/dummy/app/controllers/components-examples/flexberry-lookup/settings-example.js
@@ -177,6 +177,7 @@ export default EditFormController.extend({
     '  remove="removeLookupValue"<br>' +
     '  autocomplete=autocomplete<br>' +
     '  autocompletePersistValue=autocompletePersistValue<br>' +
+    '  autocompleteDirection=autocompleteDirection<br>' +
     '  usePaginationForAutocomplete=usePaginationForAutocomplete<br>' +
     '  maxResults=maxResults<br>' +
     '  displayValue=model.lookupDisplayValue<br>' +
@@ -234,6 +235,13 @@ export default EditFormController.extend({
       settingType: 'boolean',
       settingDefaultValue: false,
       bindedControllerPropertieName: 'usePaginationForAutocomplete'
+    });
+    componentSettingsMetadata.pushObject({
+      settingName: 'autocompleteDirection',
+      settingType: 'enumeration',
+      settingDefaultValue: 'downward',
+      settingAvailableItems: ['downward', 'upward', 'auto'],
+      bindedControllerPropertieName: 'autocompleteDirection'
     });
     componentSettingsMetadata.pushObject({
       settingName: 'maxResults',

--- a/tests/dummy/app/templates/components-examples/flexberry-lookup/settings-example.hbs
+++ b/tests/dummy/app/templates/components-examples/flexberry-lookup/settings-example.hbs
@@ -35,6 +35,7 @@
         previewOnSeparateRoute=previewOnSeparateRoute
         previewFormRoute="ember-flexberry-dummy-suggestion-type-edit"
         preview=(action "previewLookupValue")
+        autocompleteDirection=autocompleteDirection
       }}
     {{/settings-example}}
   </div>

--- a/tests/integration/components/flexberry-lookup-test.js
+++ b/tests/integration/components/flexberry-lookup-test.js
@@ -361,3 +361,111 @@ test('preview with readonly renders properly', function(assert) {
     assert.strictEqual($lookupButtonPreview.hasClass('disabled'), false, 'Component\'s container has not \'disabled\' css-class');
   });
 });
+
+test('autocompleteDirection adds no css-class if autocompleteDirection is not defined', function(assert) {
+  let store = app.__container__.lookup('service:store');
+
+  Ember.run(() => {
+    Ember.set(this, 'model', store.createRecord('ember-flexberry-dummy-suggestion', {
+      name: 'TestTypeName'
+    }));
+
+    this.render(hbs`{{flexberry-lookup
+      value=model.type
+      relationName="parent"
+      projection="SettingLookupExampleView"
+      displayAttributeName="name"
+      title="Parent"
+      autocomplete=true
+      relatedModel=model
+      relationName="type"
+    }}`);
+  });
+
+  let $resultAutocomplete = this.$('div.results');
+  assert.equal($resultAutocomplete.length, 1, 'Component has autocomplete window.');
+  assert.equal($resultAutocomplete.hasClass('visible'), false, 'Autocomplete window is not visible until we start typing.');
+
+  let $lookupField = this.$('input.lookup-field');
+  fillIn($lookupField, 'g');
+
+  let asyncOperationsCompleted = assert.async();
+    Ember.run.later(function() {
+      asyncOperationsCompleted();
+      assert.equal($resultAutocomplete.hasClass('visible'), true, 'Autocomplete window is now visible.');
+      assert.equal($resultAutocomplete.hasClass('upward'), false, 'Autocomplete window has no extra class.')
+    }, 5000);
+});
+
+test('autocompleteDirection adds css-class if autocompleteDirection is defined as upward', function(assert) {
+  let store = app.__container__.lookup('service:store');
+
+  Ember.run(() => {
+    Ember.set(this, 'model', store.createRecord('ember-flexberry-dummy-suggestion', {
+      name: 'TestTypeName'
+    }));
+
+    Ember.set(this, 'autocompleteDirection', undefined);
+    this.render(hbs`{{flexberry-lookup
+      value=model.type
+      relationName="parent"
+      projection="SettingLookupExampleView"
+      displayAttributeName="name"
+      title="Parent"
+      autocomplete=true
+      autocompleteDirection="upward"
+      relatedModel=model
+      relationName="type"
+    }}`);
+  });
+
+  let $resultAutocomplete = this.$('div.results');
+  assert.equal($resultAutocomplete.length, 1, 'Component has autocomplete window.');
+  assert.equal($resultAutocomplete.hasClass('visible'), false, 'Autocomplete window is not visible until we start typing.');
+
+  let $lookupField = this.$('input.lookup-field');
+  fillIn($lookupField, 'g');
+
+  let asyncOperationsCompleted = assert.async();
+    Ember.run.later(function() {
+      asyncOperationsCompleted();
+      assert.equal($resultAutocomplete.hasClass('visible'), true, 'Autocomplete window is now visible.');
+      assert.equal($resultAutocomplete.hasClass('upward'), true, 'Autocomplete window has extra class.')
+    }, 5000);
+});
+
+test('autocompleteDirection adds no css-class if autocompleteDirection is defined as downward', function(assert) {
+  let store = app.__container__.lookup('service:store');
+
+  Ember.run(() => {
+    Ember.set(this, 'model', store.createRecord('ember-flexberry-dummy-suggestion', {
+      name: 'TestTypeName'
+    }));
+
+    this.render(hbs`{{flexberry-lookup
+      value=model.type
+      relationName="parent"
+      projection="SettingLookupExampleView"
+      displayAttributeName="name"
+      title="Parent"
+      autocomplete=true
+      autocompleteDirection="downward"
+      relatedModel=model
+      relationName="type"
+    }}`);
+  });
+
+  let $resultAutocomplete = this.$('div.results');
+  assert.equal($resultAutocomplete.length, 1, 'Component has autocomplete window.');
+  assert.equal($resultAutocomplete.hasClass('visible'), false, 'Autocomplete window is not visible until we start typing.');
+
+  let $lookupField = this.$('input.lookup-field');
+  fillIn($lookupField, 'g');
+
+  let asyncOperationsCompleted = assert.async();
+    Ember.run.later(function() {
+      asyncOperationsCompleted();
+      assert.equal($resultAutocomplete.hasClass('visible'), true, 'Autocomplete window is now visible.');
+      assert.equal($resultAutocomplete.hasClass('upward'), false, 'Autocomplete window has no extra class.')
+    }, 5000);
+});


### PR DESCRIPTION
Added property autocompleteDirection.
It can be auto, upward, downward (default value is downward for backward compatibility).
If set to upward it shows autocomplete window up, if set to auto - based on current position, otherwise - down.

Documentation for lookup is udated too (but the article about lookups is on pull request yet)
