### PR TITLE
Optimized sort at FGE, with unit tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -190,6 +190,7 @@ tests/acceptance/components/flexberry-dropdown/flexberry-dropdown-empty-value-te
 tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-check-all-at-page-test.js
 tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-configurate-row-test.js
 tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-user-button-test.js
+tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-check-sort-test.js
 tests/acceptance/components/flexberry-lookup/change-component-lookup-test.js
 tests/acceptance/components/flexberry-lookup/change-model-lookup-test.js
 tests/acceptance/components/flexberry-lookup/execute-flexberry-lookup-test.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+* The `flexberry-groupedit` component:
+    * Optimized sort function.
 
 ## [2.7.0-beta.3] - 2021-09-28
 ### Added

--- a/addon/components/flexberry-groupedit.js
+++ b/addon/components/flexberry-groupedit.js
@@ -654,9 +654,30 @@ export default FlexberryBaseComponent.extend({
   */
   sortRecords(records, sortDef, start, end) {
     let recordsSort = records;
-    let condition = function(koef) {
-      let firstProp = recordsSort.objectAt(koef - 1).get(sortDef.attributePath || sortDef.propName);
-      let secondProp = recordsSort.objectAt(koef).get(sortDef.attributePath || sortDef.propName);
+    if (start >= end) {
+      return recordsSort;
+    }
+
+    // Form hash array (there can be different observers on recordsSort changing, so it is better to minimize such changes).
+    let hashArray = [];
+    for (let i = start; i <= end; i++) {
+      let currentRecord = recordsSort.objectAt(i);
+      let currentHash = currentRecord.get(sortDef.attributePath || sortDef.propName);
+      let hashStructure = {
+        record: currentRecord,
+        hash: currentHash
+      };
+
+      hashArray.push(hashStructure);
+    }
+
+    let hashArrayLength = hashArray.length;
+
+    // Compare record with number koef1 and koef2.
+    // It returns true if records should be exchanged.
+    let condition = function(koef1, koef2) {
+      let firstProp = hashArray[koef1].hash;
+      let secondProp = hashArray[koef2].hash;
       if (sortDef.direction === 'asc') {
         return Ember.isNone(secondProp) && !Ember.isNone(firstProp) ? true : firstProp > secondProp;
       }
@@ -668,12 +689,29 @@ export default FlexberryBaseComponent.extend({
       return false;
     };
 
-    for (let i = start + 1; i <= end; i++) {
-      for (let j = i; j > start && condition(j); j--) {
-        let record = recordsSort.objectAt(j);
-        recordsSort.removeAt(j);
-        recordsSort.insertAt(j - 1, record);
+    // Sort with minimum exchanges.
+    for(let i = 0; i < hashArrayLength; i++) {
+      // Find minimum in right not sorted part.
+      let min = i;
+      for(let j = i + 1; j < hashArrayLength; j++) {
+        if(condition(min, j)) {
+          min = j; 
+        }
       }
+      if (min != i) {
+        // Exchange current with minimum.
+        let tmp = hashArray[i]; 
+        hashArray[i] = hashArray[min];
+        hashArray[min] = tmp;      
+      }
+    }
+    
+    // Remove unsorted part.
+    recordsSort.removeAt(start, end - start + 1);
+
+    // Insert sorted elements.
+    for (let i = start; i <= end; i++) {
+      recordsSort.insertAt(i, hashArray[i-start].record);
     }
 
     return recordsSort;

--- a/tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-sort-test.js
+++ b/tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-sort-test.js
@@ -1,0 +1,146 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../../../helpers/start-app';
+
+let app;
+let flexberryGroupeditComponent;
+let store;
+const testName = 'sort test';
+
+module('Acceptance | flexberry-groupedit | ' + testName, {
+  needs: [
+    'model:ember-flexberry-dummy-suggestion'
+  ],
+  beforeEach() {
+    // Start application.
+    app = startApp();
+    flexberryGroupeditComponent = app.__container__.lookup('component:flexberry-groupedit');
+    store = app.__container__.lookup('service:store');
+  },
+
+  afterEach() {
+    Ember.run(app, 'destroy');
+  }
+});
+
+test(testName, (assert) => {
+  assert.expect(78);
+  let recordArray = new Ember.A();
+
+  Ember.run(() => {
+    recordArray.insertAt(0, store.createRecord(
+      'ember-flexberry-dummy-suggestion',
+      {
+        id: 1,
+        address: 'Alphabeth5',
+        text: 'Beatrith5',
+        date: new Date(2021, 10, 6, 12, 45, 0),
+        moderated: false
+      }));
+    recordArray.insertAt(1, store.createRecord(
+      'ember-flexberry-dummy-suggestion',
+      {
+        id: 2,
+        address: 'Alphabeth4',
+        text: 'Beatrith4',
+        date: new Date(2020, 10, 6, 12, 45, 0),
+        moderated: true
+      }));
+    recordArray.insertAt(2, store.createRecord(
+      'ember-flexberry-dummy-suggestion',
+      {
+        id: 3,
+        address: 'Alphabeth3',
+        text: 'Beatrith1',
+        date: new Date(2022, 10, 6, 12, 45, 0),
+        moderated: true
+      }));
+    recordArray.insertAt(3, store.createRecord(
+      'ember-flexberry-dummy-suggestion',
+      {
+        id: 4,
+        address: 'Alphabeth2',
+        text: 'Beatrith2',
+        date: new Date(2021, 11, 6, 12, 45, 0),
+        moderated: true
+      }));
+    recordArray.insertAt(4, store.createRecord(
+      'ember-flexberry-dummy-suggestion',
+      {
+        id: 5,
+        address: 'Alphabeth1',
+        text: 'Beatrith3',
+        date: new Date(2021, 9, 6, 12, 45, 0),
+        moderated: true
+      }));
+  });
+  
+  try {
+    let sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'address', direction: 'asc'}, 0, 4);
+    specialArrayCompare(sortResult, [5, 4, 3, 2, 1], assert, 'sortRecords | text | asc');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'address', direction: 'desc'}, 0, 4);
+    specialArrayCompare(sortResult, [1, 2, 3, 4, 5], assert, 'sortRecords | text | desc');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'address', direction: 'none'}, 0, 4);
+    specialArrayCompare(sortResult, [1, 2, 3, 4, 5], assert, 'sortRecords | text | none');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'date', direction: 'asc'}, 0, 4);
+    specialArrayCompare(sortResult, [2, 5, 1, 4, 3], assert, 'sortRecords | date | asc');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'date', direction: 'desc'}, 0, 4);
+    specialArrayCompare(sortResult, [3, 4, 1, 5, 2], assert, 'sortRecords | date | desc');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'date', direction: 'none'}, 0, 4);
+    specialArrayCompare(sortResult, [3, 4, 1, 5, 2], assert, 'sortRecords | date | none');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'moderated', direction: 'asc'}, 0, 4);
+    specialArrayCompare(sortResult, [1, 4, 3, 5, 2], assert, 'sortRecords | boolean | asc');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'moderated', direction: 'desc'}, 0, 4);
+    specialArrayCompare(sortResult, [4, 3, 5, 2, 1], assert, 'sortRecords | boolean | desc');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'moderated', direction: 'none'}, 0, 4);
+    specialArrayCompare(sortResult, [4, 3, 5, 2, 1], assert, 'sortRecords | boolean | none');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'id', direction: 'asc'}, 0, 4);
+    specialArrayCompare(sortResult, [1, 2, 3, 4, 5], assert, 'sortRecords | id | asc');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'address', direction: 'asc'}, 1, 3);
+    specialArrayCompare(sortResult, [1, 4, 3, 2, 5], assert, 'sortRecords | partial sort | asc');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'address', direction: 'asc'}, 1, 4);
+    specialArrayCompare(sortResult, [1, 5, 4, 3, 2], assert, 'sortRecords | partial sort | asc');
+
+    sortResult = flexberryGroupeditComponent.sortRecords(
+      recordArray, { propName: 'address', direction: 'desc'}, 0, 3);
+    specialArrayCompare(sortResult, [1, 3, 4, 5, 2], assert, 'sortRecords | partial sort | desc');
+  }
+  finally {
+    Ember.run(() => {
+      recordArray.forEach(currentRecord => {
+        store.deleteRecord(currentRecord);
+      });
+    });
+  }
+
+});
+
+function specialArrayCompare(resultArray, compareArray, assert, message) {
+  assert.equal(compareArray.length, resultArray.length, message + ' | Length');
+  for (let i = 0; i < compareArray.length; i++) {
+    assert.equal(compareArray[i], resultArray.objectAt(i).id, message  + ' | Data ' + i);
+  }
+}


### PR DESCRIPTION
Изменён механизм сортировки во Flexberry Groupedit, чтобы минимизировать изменение исходного массива промежуточными перестановками. Связано это с тем, что на некоторых прикладных проектах на изменение исходного массива висит логика, требующая значительного времени.