### PR TITLE
Feature delete record with details without extra separate detail delete

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -191,6 +191,7 @@ tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-check-all-at
 tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-configurate-row-test.js
 tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-user-button-test.js
 tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-check-sort-test.js
+tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-delete-with-details-test.js
 tests/acceptance/components/flexberry-lookup/change-component-lookup-test.js
 tests/acceptance/components/flexberry-lookup/change-model-lookup-test.js
 tests/acceptance/components/flexberry-lookup/execute-flexberry-lookup-test.js
@@ -282,6 +283,7 @@ tests/dummy/app/controllers/components-acceptance-tests/flexberry-lookup/setting
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-lookup/settings-example-preview.js
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-lookup/settings-example-projection.js
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-lookup/settings-example.js
+tests/dummy/app/controllers/components-acceptance-tests/flexberry-groupedit/delete-with-details.js
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/base-operations.js
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/computable-field.js
@@ -404,6 +406,7 @@ tests/dummy/app/routes/components-acceptance-tests/flexberry-lookup/settings-exa
 tests/dummy/app/routes/components-acceptance-tests/flexberry-lookup/settings-example-projection.js
 tests/dummy/app/routes/components-acceptance-tests/flexberry-lookup/settings-example-relation-name.js
 tests/dummy/app/routes/components-acceptance-tests/flexberry-lookup/settings-example.js
+tests/dummy/app/routes/components-acceptance-tests/flexberry-groupedit/delete-with-details.js
 tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/base-operations.js
 tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
 tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/computable-field.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -235,6 +235,7 @@ tests/acceptance/components/flexberry-objectlistview/folv-delete-button-in-row-t
 tests/acceptance/components/flexberry-objectlistview/folv-delete-button-test.js
 tests/acceptance/components/flexberry-objectlistview/folv-delete-record-from-e-form-test.js
 tests/acceptance/components/flexberry-objectlistview/folv-delete-record-from-olv-test.js
+tests/acceptance/components/flexberry-objectlistview/folv-delete-with-details-test.js
 tests/acceptance/components/flexberry-objectlistview/folv-edit-button-in-row-test.js
 tests/acceptance/components/flexberry-objectlistview/folv-from-edit-form-with-queryparams-test.js
 tests/acceptance/components/flexberry-objectlistview/folv-getCellComponent-test.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -283,6 +283,7 @@ tests/dummy/app/controllers/components-acceptance-tests/flexberry-lookup/setting
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-lookup/settings-example-projection.js
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-lookup/settings-example.js
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/base-operations.js
+tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/computable-field.js
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/custom-filter.js
 tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/date-format.js
@@ -404,6 +405,7 @@ tests/dummy/app/routes/components-acceptance-tests/flexberry-lookup/settings-exa
 tests/dummy/app/routes/components-acceptance-tests/flexberry-lookup/settings-example-relation-name.js
 tests/dummy/app/routes/components-acceptance-tests/flexberry-lookup/settings-example.js
 tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/base-operations.js
+tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
 tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/computable-field.js
 tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/custom-filter.js
 tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/date-format.js

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -867,6 +867,12 @@ module.exports = {
       ]
     },
     {
+      "moduleId": "tests/dummy/app/templates/components-acceptance-tests/flexberry-groupedit/delete-with-details",
+      "only": [
+        "eol-last"
+      ]
+    },
+    {
       "moduleId": "tests/dummy/app/templates/components-acceptance-tests/flexberry-objectlistview/delete-with-details",
       "only": [
         "eol-last"

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -867,6 +867,12 @@ module.exports = {
       ]
     },
     {
+      "moduleId": "tests/dummy/app/templates/components-acceptance-tests/flexberry-objectlistview/delete-with-details",
+      "only": [
+        "eol-last"
+      ]
+    },
+    {
       "moduleId": "tests/dummy/app/templates/components-acceptance-tests/flexberry-objectlistview/computable-field",
       "only": [
         "eol-last"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 * The `flexberry-model-init` blueprint check additional options for audit and insert necessary mixin.
+* The `flexberry-objectlistview` deletes only record itself and unloads its details (details are deleted on database by ORM or by adapter on offline).
 
 ## [2.7.0-beta.6] - 2022-02-08
 ### Added

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-flexberry-data": "~2.7.0-beta.1",
+    "ember-flexberry-data": "~2.7.0-beta.0",
     "ember-i18n": "4.2.0",
     "ember-test-selectors": "2.1.0",
     "ember-truth-helpers": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-flexberry-data": "~2.7.0-beta.0",
+    "ember-flexberry-data": "~2.7.0-beta.1",
     "ember-i18n": "4.2.0",
     "ember-test-selectors": "2.1.0",
     "ember-truth-helpers": "1.2.0",

--- a/tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-delete-with-details-test.js
+++ b/tests/acceptance/components/flexberry-groupedit/flexberry-groupedit-delete-with-details-test.js
@@ -32,6 +32,7 @@ module('Acceptance | flexberry-groupedit | delete with details', {
   });
 
 test('delete with details', (assert) => {
+  let mainSuggestionRecord; 
   let initTestData = function(createdRecordsPrefix) {
     // Add records for deleting. 
     return Ember.RSVP.Promise.all([
@@ -45,8 +46,9 @@ test('delete with details', (assert) => {
     .then((createdCustomRecords) => 
       Ember.RSVP.Promise.all([
         store.createRecord(modelName, { text: createdRecordsPrefix + "0", type: createdCustomRecords[0], author: createdCustomRecords[1], editor1: createdCustomRecords[1] }).save()])
-      .then((suggestions) => 
-        Ember.RSVP.Promise.all([
+      .then((suggestions) => {
+        mainSuggestionRecord = suggestions[0];
+        return Ember.RSVP.Promise.all([
           store.createRecord(commentModelName, { text: createdRecordsPrefix + "0", suggestion: suggestions[0], author: createdCustomRecords[1] }).save(),
           store.createRecord(commentModelName, { text: createdRecordsPrefix + "1", suggestion: suggestions[0], author: createdCustomRecords[1] }).save(),
           store.createRecord(commentModelName, { text: createdRecordsPrefix + "2", suggestion: suggestions[0], author: createdCustomRecords[1] }).save()])
@@ -55,57 +57,7 @@ test('delete with details', (assert) => {
             store.createRecord(commentVoteModelName, { name: createdRecordsPrefix + "0", comment: comments[0], applicationUser: createdCustomRecords[1] }).save(),
             store.createRecord(commentVoteModelName, { name: createdRecordsPrefix + "1", comment: comments[0], applicationUser: createdCustomRecords[1] }).save(),
             store.createRecord(commentVoteModelName, { name: createdRecordsPrefix + "2", comment: comments[1], applicationUser: createdCustomRecords[1] }).save()])
-        )))
-    };
-
-  Ember.run(() => {
-    let done1 = assert.async();
-    let createdRecordsPrefix = 'fge-delete-with-details-test' + generateUniqueId();
-    initTestData(createdRecordsPrefix).then(() => {
-      visit(path +'?createdRecordsPrefix=' + createdRecordsPrefix);
-      andThen(() => {
-        assert.equal(currentPath(), path, createdRecordsPrefix);
-        done1();
-      });
-    });
-  });
-});
-
-
-/*executeTest('check delete with details', (store, assert, app) => {
-  assert.expect(5);
-  let path = 'components-acceptance-tests/flexberry-objectlistview/delete-with-details';
-  let modelName = 'ember-flexberry-dummy-suggestion';
-  let commentModelName = 'ember-flexberry-dummy-comment';
-  let commentVoteModelName = 'ember-flexberry-dummy-comment-vote';
-
-  let initTestData = function(createdRecordsPrefix) {
-    // Add records for deleting. 
-    return Ember.RSVP.Promise.all([
-      store.createRecord('ember-flexberry-dummy-suggestion-type', { name: createdRecordsPrefix + "0" }).save(),
-      store.createRecord('ember-flexberry-dummy-application-user', { 
-                                                                    name: createdRecordsPrefix + "1",
-                                                                    eMail: "1",
-                                                                    phone1: "1"
-                                                                   }).save()
-    ])
-    .then((createdCustomRecords) => 
-      Ember.RSVP.Promise.all([
-        store.createRecord(modelName, { text: createdRecordsPrefix + "0", type: createdCustomRecords[0], author: createdCustomRecords[1], editor1: createdCustomRecords[1] }).save(),
-        store.createRecord(modelName, { text: createdRecordsPrefix + "1", type: createdCustomRecords[0], author: createdCustomRecords[1], editor1: createdCustomRecords[1] }).save(),
-        store.createRecord(modelName, { text: createdRecordsPrefix + "2", type: createdCustomRecords[0], author: createdCustomRecords[1], editor1: createdCustomRecords[1] }).save()])
-      .then((suggestions) => 
-        Ember.RSVP.Promise.all([
-          store.createRecord(commentModelName, { text: createdRecordsPrefix + "0", suggestion: suggestions[0], author: createdCustomRecords[1] }).save(),
-          store.createRecord(commentModelName, { text: createdRecordsPrefix + "1", suggestion: suggestions[0], author: createdCustomRecords[1] }).save(),
-          store.createRecord(commentModelName, { text: createdRecordsPrefix + "2", suggestion: suggestions[1], author: createdCustomRecords[1] }).save(),
-          store.createRecord(commentModelName, { text: createdRecordsPrefix + "3", suggestion: suggestions[1], author: createdCustomRecords[1] }).save()])
-        .then((comments) => 
-          Ember.RSVP.Promise.all([
-            store.createRecord(commentVoteModelName, { name: createdRecordsPrefix + "0", comment: comments[0], applicationUser: createdCustomRecords[1] }).save(),
-            store.createRecord(commentVoteModelName, { name: createdRecordsPrefix + "1", comment: comments[0], applicationUser: createdCustomRecords[1] }).save(),
-            store.createRecord(commentVoteModelName, { name: createdRecordsPrefix + "2", comment: comments[1], applicationUser: createdCustomRecords[1] }).save()])
-        )))
+        )}))
     };
 
   let getRows = function(){
@@ -122,7 +74,7 @@ test('delete with details', (assert) => {
 
     // Check that the records have been added.
     let recordIsForDeleting = $rows().reduce((sum, element) => {
-      let nameRecord = Ember.$.trim(element.children[2].innerText);
+      let nameRecord = Ember.$.trim(element.children[1].children[0].children[0].value);
       let flag = nameRecord.indexOf(searchedRecord) >= 0;
       return sum + flag;
     }, 0);
@@ -134,7 +86,7 @@ test('delete with details', (assert) => {
     let $rows = getRows();
     let $deleteBtnInRow = undefined;
     $rows().forEach(function(element)  {
-      let nameRecord = Ember.$.trim(element.children[2].innerText);
+      let nameRecord = Ember.$.trim(element.children[1].children[0].children[0].value);
       if (nameRecord.indexOf(searchedRecord) >= 0) {
         $deleteBtnInRow = Ember.$('.object-list-view-row-delete-button', element);
       }
@@ -154,94 +106,64 @@ test('delete with details', (assert) => {
     return false;
   };
 
-  // Add records for deleting.
   Ember.run(() => {
     let done1 = assert.async();
-    let createdRecordsPrefix = 'folv-delete-with-details-test' + generateUniqueId();
+    let createdRecordsPrefix = 'fge-delete-with-details-test' + generateUniqueId();
     initTestData(createdRecordsPrefix).then(() => {
-      let builder = new QueryBuilder(store).from(modelName).count();
-      let done = assert.async();
-      store.query(modelName, builder.build()).then((result) => {
-        visit(path + '?perPage=' + result.meta.count);
-        andThen(() => {
-          assert.equal(currentPath(), path);
+      visit(path +'?createdRecordsPrefix=' + createdRecordsPrefix);
+      andThen(() => {
+        assert.equal(currentPath(), path, createdRecordsPrefix);
 
-          // Check records added.
-          assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "0") > 0, true, 1 + ' record added');
-          assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "1") > 0, true, 2 + ' record added');
-          assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "2") > 0, true, 3 + ' record added');
+        // Check records added.
+        assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "0") > 0, true, 1 + ' record added');
+        assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "1") > 0, true, 2 + ' record added');
+        assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "2") > 0, true, 3 + ' record added');
 
-          let $deleteButton1 = getDeleteButton(createdRecordsPrefix + "0");
-          let done2 = assert.async();
-          Ember.run(() => {
-            // An exception can be thrown to console due to observer on detail's count.
-            $deleteButton1.click();
-          });
-          wait().then(() => {
-            assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "0"), 0, 1 + ' record deleted');
-            assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "1") > 0, true, 2 + ' still on OLV');
-            assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "2") > 0, true, 3 + ' still on OLV');
-            
-            // Check local storage.
-            assert.notOk(lookAtLocalStore(modelName, 'text', createdRecordsPrefix + "0"), "1 suggestion deleted on store");
-            assert.ok(lookAtLocalStore(modelName, 'text', createdRecordsPrefix + "1"), "2 suggestion still on store");
-            assert.ok(lookAtLocalStore(modelName, 'text', createdRecordsPrefix + "2"), "3 suggestion still on store");
-
-            assert.notOk(lookAtLocalStore(commentModelName, 'text', createdRecordsPrefix + "0"), "1 comment deleted");
-            assert.notOk(lookAtLocalStore(commentModelName, 'text', createdRecordsPrefix + "1"), "2 comment deleted");
-            assert.ok(lookAtLocalStore(commentModelName, 'text', createdRecordsPrefix + "2"), "3 comment still on store");
-            assert.ok(lookAtLocalStore(commentModelName, 'text', createdRecordsPrefix + "3"), "4 comment still on store");
-
-            assert.notOk(lookAtLocalStore(commentVoteModelName, 'comment.text', createdRecordsPrefix + "0"), "Comment vote deleted");
-            assert.notOk(lookAtLocalStore(commentVoteModelName, 'comment.text', createdRecordsPrefix + "1"), "Comment vote deleted");
-
-            let builder = new QueryBuilder(store, modelName)
-              .where(new SimplePredicate('text', "==", createdRecordsPrefix + "0"));
-            let done3 = assert.async();
-            store.query(modelName, builder.build())
-            .then((data) => {
-              assert.equal(data.get('length'), 0, '1 suggestion deleted on backend');
-
-              let $deleteButton2 = getDeleteButton(createdRecordsPrefix + "1");
-              let done4 = assert.async();
-              Ember.run(() => {
-                // An exception can be thrown to console due to observer on detail's count.
-                $deleteButton2.click();
-              });
-              wait().then(() => {
-                assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "1"), 0, 2 + ' record deleted');
-                assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "2") > 0, true, 3 + ' still on OLV');
-                
-                // Check local storage.
-                assert.notOk(lookAtLocalStore(modelName, 'text', createdRecordsPrefix + "1"), "2 suggestion deleted on store");
-                assert.ok(lookAtLocalStore(modelName, 'text', createdRecordsPrefix + "2"), "3 suggestion still on store");
-
-                assert.notOk(lookAtLocalStore(commentModelName, 'text', createdRecordsPrefix + "2"), "3 comment deleted");
-                assert.notOk(lookAtLocalStore(commentModelName, 'text', createdRecordsPrefix + "3"), "4 comment deleted");
-
-                let $deleteButton3 = getDeleteButton(createdRecordsPrefix + "2");
-                let done5 = assert.async();
-                Ember.run(() => {
-                  // An exception can be thrown to console due to observer on detail's count.
-                  $deleteButton3.click();
-                });
-                wait().then(() => {
-                  assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "2"), 0, 3 + ' record deleted');
-                  
-                  // Check local storage.
-                  assert.notOk(lookAtLocalStore(modelName, 'text', createdRecordsPrefix + "2"), "3 suggestion deleted on store");
-                  done5();
-                });
-                done4();
-              });
-              done3();
-            });
-            done2();
-          });
+        let $deleteButton1 = getDeleteButton(createdRecordsPrefix + "0");
+        let done2 = assert.async();
+        Ember.run(() => {
+          // An exception can be thrown to console due to observer on detail's count.
+          $deleteButton1.click();
         });
-        done();
+
+        wait().then(() => {
+          assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "0"), 0, 1 + ' record deleted');
+          assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "1") > 0, true, 2 + ' still on OLV');
+          assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "2") > 0, true, 3 + ' still on OLV');
+          
+          assert.notOk(lookAtLocalStore(commentModelName, 'text', createdRecordsPrefix + "0"), "1 comment deleted");
+          assert.ok(lookAtLocalStore(commentModelName, 'text', createdRecordsPrefix + "1"), "2 comment still on store");
+          assert.ok(lookAtLocalStore(commentModelName, 'text', createdRecordsPrefix + "2"), "3 comment still on store");
+
+          assert.notOk(lookAtLocalStore(commentVoteModelName, 'comment.text', createdRecordsPrefix + "0"), "Comment votes for 1 deleted");
+          assert.ok(lookAtLocalStore(commentVoteModelName, 'comment.text', createdRecordsPrefix + "1"), "Comment votes for 2 still on store");
+
+          let builder = new QueryBuilder(store, commentModelName)
+            .where(new SimplePredicate('text', "==", createdRecordsPrefix + "0"));
+          let done3 = assert.async();
+          store.query(commentModelName, builder.build())
+          .then((data) => {
+            assert.equal(data.get('length'), 1, '1 comment is not deleted on backend');
+
+            let builder = new QueryBuilder(store, commentVoteModelName)
+              .where(new SimplePredicate('comment.text', "==", createdRecordsPrefix + "0"));
+            let done4 = assert.async();
+            store.query(commentVoteModelName, builder.build())
+            .then((data) => {
+              assert.equal(data.get('length'), 2, 'Comment votes for comment 1 not deleted on backend');
+              let done5 = assert.async();
+
+              // An exception can be thrown to console due to observer on detail's count.
+              mainSuggestionRecord.destroyRecord().then(() => done5());
+              done4();
+            });
+            done3();
+          });
+          done2();
+        });
+        done1();
       });
-      done1();
     });
   });
-});*/
+});
+

--- a/tests/acceptance/components/flexberry-objectlistview/folv-delete-with-details-test.js
+++ b/tests/acceptance/components/flexberry-objectlistview/folv-delete-with-details-test.js
@@ -1,0 +1,117 @@
+import Ember from 'ember';
+import { executeTest, addDataForDestroy } from './execute-folv-test';
+import generateUniqueId from 'ember-flexberry-data/utils/generate-unique-id';
+
+import { Query } from 'ember-flexberry-data';
+const { Builder } = Query;
+
+executeTest('check delete with details', (store, assert, app) => {
+  assert.expect(5);
+  let path = 'components-acceptance-tests/flexberry-objectlistview/delete-with-details';
+  let modelName = 'ember-flexberry-dummy-suggestion';
+  let commentModelName = 'ember-flexberry-dummy-comment';
+  let commentVoteModelName = 'ember-flexberry-dummy-comment-vote';
+
+  let initTestData = function(createdRecordsPrefix) {
+    // Add records for deleting. 
+    return Ember.RSVP.Promise.all([
+      store.createRecord('ember-flexberry-dummy-suggestion-type', { name: createdRecordsPrefix + "0" }).save(),
+      store.createRecord('ember-flexberry-dummy-application-user', { 
+                                                                    name: createdRecordsPrefix + "1",
+                                                                    eMail: "1",
+                                                                    phone1: "1"
+                                                                   }).save()
+    ])
+    .then((createdCustomRecords) => 
+      Ember.RSVP.Promise.all([
+        store.createRecord(modelName, { text: createdRecordsPrefix + "0", type: createdCustomRecords[0], author: createdCustomRecords[1], editor1: createdCustomRecords[1] }).save(),
+        store.createRecord(modelName, { text: createdRecordsPrefix + "1", type: createdCustomRecords[0], author: createdCustomRecords[1], editor1: createdCustomRecords[1] }).save(),
+        store.createRecord(modelName, { text: createdRecordsPrefix + "2", type: createdCustomRecords[0], author: createdCustomRecords[1], editor1: createdCustomRecords[1] }).save()])
+      .then((suggestions) => 
+        Ember.RSVP.Promise.all([
+          store.createRecord(commentModelName, { text: createdRecordsPrefix + "0", suggestion: suggestions[0], author: createdCustomRecords[1] }).save(),
+          store.createRecord(commentModelName, { text: createdRecordsPrefix + "1", suggestion: suggestions[0], author: createdCustomRecords[1] }).save(),
+          store.createRecord(commentModelName, { text: createdRecordsPrefix + "2", suggestion: suggestions[1], author: createdCustomRecords[1] }).save(),
+          store.createRecord(commentModelName, { text: createdRecordsPrefix + "3", suggestion: suggestions[1], author: createdCustomRecords[1] }).save()])
+        .then((comments) => 
+          Ember.RSVP.Promise.all([
+            store.createRecord(commentVoteModelName, { name: createdRecordsPrefix + "0", comment: comments[0], applicationUser: createdCustomRecords[1] }).save(),
+            store.createRecord(commentVoteModelName, { name: createdRecordsPrefix + "1", comment: comments[0], applicationUser: createdCustomRecords[1] }).save(),
+            store.createRecord(commentVoteModelName, { name: createdRecordsPrefix + "2", comment: comments[1], applicationUser: createdCustomRecords[1] }).save()])
+        )))
+    };
+
+  let checkRecordsWereAdded = function(searchedRecord) {
+    let olvContainerClass = '.object-list-view-container';
+    let trTableClass = 'table.object-list-view tbody tr';
+
+    let $folvContainer = Ember.$(olvContainerClass);
+    let $rows = () => { return Ember.$(trTableClass, $folvContainer).toArray(); };
+
+    // Check that the records have been added.
+    let recordIsForDeleting = $rows().reduce((sum, element) => {
+      let nameRecord = Ember.$.trim(element.children[2].innerText);
+      let flag = nameRecord.indexOf(searchedRecord) >= 0;
+      return sum + flag;
+    }, 0);
+
+    return recordIsForDeleting;
+  };
+
+  // Add records for deleting.
+  Ember.run(() => {
+    let done1 = assert.async();
+    let createdRecordsPrefix = 'folv-delete-with-details-test' + generateUniqueId();
+    initTestData(createdRecordsPrefix).then(() => {
+      let builder = new Builder(store).from(modelName).count();
+      let done = assert.async();
+      store.query(modelName, builder.build()).then((result) => {
+        visit(path + '?perPage=' + result.meta.count);
+        andThen(() => {
+          assert.equal(currentPath(), path);
+          let controller = app.__container__.lookup('controller:' + currentRouteName());
+          controller.set('immediateDelete', true);
+
+          assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "0") > 0, true, 1 + ' record added');
+          assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "1") > 0, true, 2 + ' record added');
+          assert.equal(checkRecordsWereAdded(createdRecordsPrefix + "2") > 0, true, 3 + ' record added');
+
+          /*$rows().forEach(function(element, i, arr)  {
+            let nameRecord = Ember.$.trim(element.children[1].innerText);
+            if (nameRecord.indexOf(uuid) >= 0) {
+              let $deleteBtnInRow = Ember.$('.object-list-view-row-delete-button', element);
+              $deleteBtnInRow.click();
+            }
+          });
+
+          // Check that the records wasn't remove in beforeDeleteRecord.
+          let controller = app.__container__.lookup('controller:' + currentRouteName());
+          assert.ok(controller.recordWasNotDelete, 'Records wasn\'t remove in beforeDeleteRecord');
+
+          // Check that the records haven't been removed.
+          let recordsIsDeleteBtnInRow = $rows().every((element) => {
+            let nameRecord = Ember.$.trim(element.children[1].innerText);
+            return nameRecord.indexOf(uuid) < 0;
+          });
+
+          assert.ok(recordsIsDeleteBtnInRow, 'Each entry begins with \'' + uuid + '\' is delete with button in row');
+
+          // Check that the records have been removed into store.
+          let builder2 = new Builder(store, modelName).where('name', Query.FilterOperator.Eq, uuid).count();
+          let timeout = 500;
+          Ember.run.later((function() {
+            let done2 = assert.async();
+            store.query(modelName, builder2.build()).then((result) => {
+              assert.ok(result.meta.count, 'record \'' + uuid + '\'not found in store');
+              done2();
+            }).finally(() => {
+              newRecord.destroyRecord();
+            });
+          }), timeout);*/
+        });
+        done();
+      });
+      done1();
+    });
+  });
+});

--- a/tests/dummy/app/controllers/components-acceptance-tests/flexberry-groupedit/delete-with-details.js
+++ b/tests/dummy/app/controllers/components-acceptance-tests/flexberry-groupedit/delete-with-details.js
@@ -1,0 +1,137 @@
+import BaseEditFormController from 'ember-flexberry/controllers/edit-form';
+import EditFormControllerOperationsIndicationMixin from 'ember-flexberry/mixins/edit-form-controller-operations-indication';
+
+export default BaseEditFormController.extend(EditFormControllerOperationsIndicationMixin, {
+  queryParams: ['createdRecordsPrefix'],
+
+  createdRecordsPrefix: undefined,
+
+  /**
+    Route name for transition after close edit form.
+
+    @property parentRoute
+    @type String
+    @default 'ember-flexberry-dummy-suggestion-list'
+   */
+  parentRoute: 'ember-flexberry-dummy-suggestion-list',
+
+  /**
+    Available file extensions for upload. In MIME type format.
+
+    @property availableMimeTypes
+    @type String
+  */
+  availableMimeTypes: 'text/plain,video/mp4',
+
+  /**
+    Maximum file size in bytes for uploading files.
+    It should be greater then 0 and less or equal then APP.components.file.maxUploadFileSize from application config\environment.
+    If null or undefined, then APP.components.file.maxUploadFileSize from application config\environment will be used.
+
+    @property maxUploadFileSize
+    @type Number
+  */
+  maxUploadFileSize: 10,
+
+  /**
+    Maximum file size unit. May be 'Bt' 'Kb' 'Mb' or 'Gb'.
+
+    @property maxUploadFileSizeUnit
+    @type String
+  */
+  maxUploadFileSizeUnit: 'Mb',
+
+  /**
+    Name of model.comments edit route.
+
+    @property commentsEditRoute
+    @type String
+    @default 'ember-flexberry-dummy-comment-edit'
+   */
+  commentsEditRoute: 'ember-flexberry-dummy-comment-edit',
+
+  /**
+    Function for check uploaded file type.
+
+    @method checkFileType
+    @param {String} fileType file type as MIME TYPES.
+    @param {String} accept available MIME TYPES.
+   */
+  checkFileType: function(fileType, accept) {
+    return true;
+  },
+
+  actions: {
+
+    getLookupFolvProperties: function() {
+      return {
+        colsConfigButton: true
+      };
+    }
+  },
+
+  /**
+    Method to get type and attributes of a component,
+    which will be embeded in object-list-view cell.
+
+    @method getCellComponent.
+    @param {Object} attr Attribute of projection property related to current table cell.
+    @param {String} bindingPath Path to model property related to current table cell.
+    @param {DS.Model} modelClass Model class of data record related to current table row.
+    @return {Object} Object containing name & properties of component, which will be used to render current table cell.
+    { componentName: 'my-component',  componentProperties: { ... } }.
+   */
+  getCellComponent(attr, bindingPath, model) {
+    let cellComponent = this._super(...arguments);
+    if (attr.kind === 'belongsTo') {
+      switch (`${model.modelName}+${bindingPath}`) {
+        case 'ember-flexberry-dummy-vote+author':
+          cellComponent.componentProperties = {
+            choose: 'showLookupDialog',
+            remove: 'removeLookupValue',
+            preview: 'previewLookupValue',
+            displayAttributeName: 'name',
+            required: true,
+            relationName: 'author',
+            projection: 'ApplicationUserL',
+            autocomplete: true,
+            showPreviewButton: true,
+            previewFormRoute: 'ember-flexberry-dummy-application-user-edit'
+          };
+          break;
+
+        case 'ember-flexberry-dummy-comment+author':
+          cellComponent.componentProperties = {
+            choose: 'showLookupDialog',
+            remove: 'removeLookupValue',
+            displayAttributeName: 'name',
+            required: true,
+            relationName: 'author',
+            projection: 'ApplicationUserL',
+            autocomplete: true,
+          };
+          break;
+
+      }
+    } else if (attr.kind === 'attr') {
+      switch (`${model.modelName}+${bindingPath}`) {
+        case 'ember-flexberry-dummy-vote+author.eMail':
+          cellComponent.componentProperties = {
+            readonly: true,
+          };
+          break;
+
+        case 'ember-flexberry-dummy-suggestion-file+file':
+          cellComponent.componentProperties = {
+            accept: this.get('availableMimeTypes'),
+            isValidTypeFileCustom: this.get('checkFileType'),
+            maxUploadFileSize: this.get('maxUploadFileSize'),
+            maxUploadFileSizeUnit: this.get('maxUploadFileSizeUnit')
+          };
+          break;
+      }
+    }
+
+    return cellComponent;
+  }
+});

--- a/tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
+++ b/tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
@@ -1,0 +1,31 @@
+import ListFormController from 'ember-flexberry/controllers/list-form';
+
+export default ListFormController.extend({
+
+  /**
+    Model projection for 'flexberry-objectlistview' component 'modelProjection' property.
+
+    @property projection
+    @type Object
+   */
+  projection: 'SuggestionE',
+
+  /**
+    Name of related edit form route (for 'flexberry-objectlistview' component 'editFormRoute' property).
+
+    @property editFormRoute
+    @type String
+   */
+  editFormRoute: 'ember-flexberry-dummy-suggestion-edit',
+
+
+  /**
+    Cout of list loading.
+
+    @property loadCount
+    @type Int
+  */
+  loadCount: 0,
+
+  immediateDelete: true
+});

--- a/tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
+++ b/tests/dummy/app/controllers/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
@@ -25,7 +25,5 @@ export default ListFormController.extend({
     @property loadCount
     @type Int
   */
-  loadCount: 0,
-
-  immediateDelete: true
+  loadCount: 0
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -199,6 +199,7 @@ Router.map(function() {
   { path: 'components-acceptance-tests/flexberry-lookup/settings-example-preview-page/:id' });
 
   this.route('components-acceptance-tests/flexberry-objectlistview/base-operations');
+  this.route('components-acceptance-tests/flexberry-objectlistview/delete-with-details');
   this.route('components-acceptance-tests/flexberry-objectlistview/computable-field');
   this.route('components-acceptance-tests/flexberry-objectlistview/folv-paging');
   this.route('components-acceptance-tests/flexberry-objectlistview/folv-user-settings');

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -198,6 +198,7 @@ Router.map(function() {
   this.route('components-acceptance-tests/flexberry-lookup/settings-example-preview-page',
   { path: 'components-acceptance-tests/flexberry-lookup/settings-example-preview-page/:id' });
 
+  this.route('components-acceptance-tests/flexberry-groupedit/delete-with-details');
   this.route('components-acceptance-tests/flexberry-objectlistview/base-operations');
   this.route('components-acceptance-tests/flexberry-objectlistview/delete-with-details');
   this.route('components-acceptance-tests/flexberry-objectlistview/computable-field');

--- a/tests/dummy/app/routes/components-acceptance-tests/flexberry-groupedit/delete-with-details.js
+++ b/tests/dummy/app/routes/components-acceptance-tests/flexberry-groupedit/delete-with-details.js
@@ -1,0 +1,103 @@
+import EditFormRoute from 'ember-flexberry/routes/edit-form';
+import EditFormRouteOperationsIndicationMixin from 'ember-flexberry/mixins/edit-form-route-operations-indication';
+import generateUniqueId from 'ember-flexberry-data/utils/generate-unique-id';
+import { Query } from 'ember-flexberry-data';
+import { SimplePredicate } from 'ember-flexberry-data/query/predicate';
+
+export default EditFormRoute.extend(EditFormRouteOperationsIndicationMixin, {
+  /**
+    Name of model projection to be used as record's properties limitation.
+
+    @property modelProjection
+    @type String
+    @default 'SuggestionE'
+   */
+  modelProjection: 'SuggestionE',
+
+  /**
+  developerUserSettings.
+  {
+  <componentName>: {
+    <settingName>: {
+        colsOrder: [ { propName :<colName>, hide: true|false }, ... ],
+        sorting: [{ propName: <colName>, direction: 'asc'|'desc' }, ... ],
+        colsWidths: [ <colName>:<colWidth>, ... ],
+      },
+      ...
+    },
+    ...
+  }
+  For default userSetting use empty name ('').
+  <componentName> may contain any of properties: colsOrder, sorting, colsWidth or being empty.
+
+  @property developerUserSettings
+  @type Object
+  @default {}
+  */
+  developerUserSettings: {
+    suggestionUserVotesGroupEdit: {
+      'DEFAULT': {
+        'columnWidths': [
+          { 'propName': 'OlvRowToolbar', 'fixed': true, 'width': 65 },
+          { 'propName': 'voteType', 'width': 133 },
+          { 'propName': 'author', 'width': 348 },
+          { 'propName': 'author.eMail', 'width': 531 }
+        ],
+        'sorting': [{ 'propName': 'author', 'direction': 'asc', 'attributePath': 'author.name' }]
+      }
+    },
+    filesGroupEdit: {
+      'DEFAULT': {
+        'columnWidths': [
+          { 'propName': 'OlvRowToolbar', 'fixed': true, 'width': 65 },
+          { 'propName': 'order', 'width': 140 },
+          { 'propName': 'file', 'width': 893 }
+        ],
+        'colsOrder': [{ 'propName': 'file' }, { 'propName': 'order' }],
+        'sorting': [{ 'propName': 'order', 'direction': 'desc' }]
+      }
+    },
+    suggestionCommentsGroupEdit: {
+      'DEFAULT': {
+        'columnWidths': [{ 'propName': 'OlvRowToolbar', 'fixed': true, 'width': 65 }, { 'propName': 'votes', 'fixed': true }],
+        'sorting': [
+          { 'propName': 'votes', 'direction': 'asc' },
+          { 'propName': 'moderated', 'direction': 'desc' },
+          { 'propName': 'text', 'direction': 'asc' }
+        ],
+      }
+    }
+  },
+
+  /**
+    Name of model to be used as form's record type.
+
+    @property modelName
+    @type String
+    @default 'ember-flexberry-dummy-suggestion'
+   */
+  modelName: 'ember-flexberry-dummy-suggestion',
+
+  /**
+   * Returns model related to current route.
+   *
+   * @param params
+   * @function model
+   */
+  model(params) {
+    const store = Ember.get(this, 'store');
+    let modelName = Ember.get(this, 'modelName')
+    let createdRecordsPrefix = (params != undefined && params['createdRecordsPrefix'] != undefined) ? params['createdRecordsPrefix'] : 'delete-with-details' + generateUniqueId();
+    
+    let query = new Query.Builder(store)
+      .from(modelName)
+      .where(new SimplePredicate('text', "==", createdRecordsPrefix + "0"))
+      .selectByProjection('SuggestionE').top(2);
+
+    return store.query(modelName, query.build()).then((suggestions) => {
+      let suggestionArr = suggestions.toArray();
+      return suggestionArr.objectAt(0);
+    });
+  }
+
+});

--- a/tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
+++ b/tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
@@ -47,15 +47,4 @@ export default ListFormRoute.extend({
    */
   modelName: 'ember-flexberry-dummy-suggestion',
 
-  /**
-    This method will be invoked always when load operation completed,
-    regardless of load promise's state (was it fulfilled or rejected).
-
-    @method onModelLoadingAlways.
-    @param {Object} data Data about completed load operation.
-   */
-  onModelLoadingAlways(data) {
-    let loadCount = this.get('controller.loadCount') + 1;
-    this.set('controller.loadCount', loadCount);
-  },
 });

--- a/tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
+++ b/tests/dummy/app/routes/components-acceptance-tests/flexberry-objectlistview/delete-with-details.js
@@ -1,0 +1,61 @@
+import ListFormRoute from 'ember-flexberry/routes/list-form';
+
+export default ListFormRoute.extend({
+  /**
+    Name of model projection to be used as record's properties limitation.
+
+    @property modelProjection
+    @type String
+    @default 'SuggestionL'
+   */
+  modelProjection: 'SuggestionE',
+
+  /**
+  developerUserSettings.
+  {
+  <componentName>: {
+    <settingName>: {
+        colsOrder: [ { propName :<colName>, hide: true|false }, ... ],
+        sorting: [{ propName: <colName>, direction: "asc"|"desc" }, ... ],
+        colsWidths: [ <colName>:<colWidth>, ... ],
+      },
+      ...
+    },
+    ...
+  }
+  For default userSetting use empty name ('').
+  <componentName> may contain any of properties: colsOrder, sorting, colsWidth or being empty.
+
+  @property developerUserSettings
+  @type Object
+  @default {}
+  */
+  developerUserSettings: {
+    FOLVSettingExampleObjectListView: {
+      'DEFAULT': {
+        'columnWidths': [{ 'propName': 'OlvRowToolbar', 'fixed': true, 'width': 120 }, { 'propName': 'OlvRowMenu', 'fixed': true, 'width': 68 }]
+      }
+    }
+  },
+
+  /**
+    Name of model to be used as list's records types.
+
+    @property modelName
+    @type String
+    @default 'ember-flexberry-dummy-suggestion'
+   */
+  modelName: 'ember-flexberry-dummy-suggestion',
+
+  /**
+    This method will be invoked always when load operation completed,
+    regardless of load promise's state (was it fulfilled or rejected).
+
+    @method onModelLoadingAlways.
+    @param {Object} data Data about completed load operation.
+   */
+  onModelLoadingAlways(data) {
+    let loadCount = this.get('controller.loadCount') + 1;
+    this.set('controller.loadCount', loadCount);
+  },
+});

--- a/tests/dummy/app/templates/components-acceptance-tests/flexberry-groupedit/delete-with-details.hbs
+++ b/tests/dummy/app/templates/components-acceptance-tests/flexberry-groupedit/delete-with-details.hbs
@@ -1,140 +1,41 @@
-  <div class="field {{if model.errors.address "error" ""}}">
-    {{flexberry-field
-      value=model.address
-      label=(t "forms.ember-flexberry-dummy-suggestion-edit.address-caption")
-      readonly=readonly
-    }}
-    {{flexberry-validationmessage error=model.errors.address pointing="pointing"}}
-  </div>
-  <div class="field {{if model.errors.text "error" ""}}">
-    {{flexberry-field
-      value=model.text
-      label=(t "forms.ember-flexberry-dummy-suggestion-edit.text-caption")
-      readonly=readonly
-    }}
-    {{flexberry-validationmessage error=model.errors.text pointing="pointing"}}
-  </div>
-  <div class="field {{if model.errors.date "error" ""}}">
-    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.date-caption"}}</label>
-    {{flexberry-simpledatetime
-      type="date"
-      value=model.date
-      readonly=readonly
-    }}
-    {{flexberry-validationmessage error=model.errors.date pointing="pointing"}}
-  </div>
-  <div class="field {{if model.errors.votes "error" ""}}">
-    {{flexberry-field
-      value=model.votes
-      label=(t "forms.ember-flexberry-dummy-suggestion-edit.votes-caption")
-      readonly=readonly
-    }}
-    {{flexberry-validationmessage error=model.errors.votes pointing="pointing"}}
-  </div>
-  <div class="field {{if model.errors.moderated "error" ""}}">
-    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.moderated-caption"}}</label>
-    {{flexberry-checkbox
-      value=model.moderated
-      readonly=readonly
-    }}
-    {{flexberry-validationmessage error=model.errors.moderated pointing="pointing"}}
-  </div>
-  <div class="field {{if model.errors.type "error" ""}}">
-    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.type-caption"}}</label>
-    {{flexberry-lookup
-      value=model.type
-      relatedModel=model
-      relationName="type"
-      projection="SuggestionTypeL"
-      displayAttributeName="name"
-      title=(t "forms.ember-flexberry-dummy-suggestion-edit.type-caption")
-      choose=(action "showLookupDialog")
-      remove=(action "removeLookupValue")
-      dropdown=true
-      readonly=readonly
-      direction="upward"
-      componentName="SuggestionEditType"
-    }}
-    {{flexberry-validationmessage error=model.errors.type pointing="pointing"}}
-  </div>
-  <div class="field {{if model.errors.author "error" ""}}">
-    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.author-caption"}}</label>
-    {{flexberry-lookup
-      value=model.author
-      relatedModel=model
-      relationName="author"
-      projection="ApplicationUserL"
-      displayAttributeName="name"
-      showPreviewButton=true
-      previewOnSeparateRoute=true
-      previewFormRoute="ember-flexberry-dummy-application-user-edit"
-      title=(t "forms.ember-flexberry-dummy-suggestion-edit.author-caption")
-      choose=(action "showLookupDialog")
-      remove=(action "removeLookupValue")
-      preview=(action "previewLookupValue")
-      lookupWindowCustomProperties=(action 'getLookupFolvProperties')
-      readonly=readonly
-      componentName="SuggestionEditAuthor"
-    }}
-    {{flexberry-validationmessage error=model.errors.author pointing="pointing"}}
-  </div>
-  <div class="field {{if model.errors.editor1 "error" ""}}">
-    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.editor1-caption"}}</label>
-    {{flexberry-lookup
-      value=model.editor1
-      relatedModel=model
-      relationName="editor1"
-      projection="ApplicationUserL"
-      displayAttributeName="name"
-      showPreviewButton=true
-      previewFormRoute="ember-flexberry-dummy-application-user-edit"
-      title=(t "forms.ember-flexberry-dummy-suggestion-edit.editor1-caption")
-      choose=(action "showLookupDialog")
-      remove=(action "removeLookupValue")
-      preview=(action "previewLookupValue")
-      readonly=readonly
-      componentName="SuggestionEditEditor1"
-    }}
-    {{flexberry-validationmessage error=model.errors.editor1 pointing="pointing"}}
-  </div>
-  <div class="field">
-    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.files-caption"}}</label>
-    {{flexberry-groupedit
-      componentName="filesGroupEdit"
-      content=model.files
-      mainModelProjection=modelProjection
-      modelProjection=modelProjection.attributes.files
-      orderable=true
-      readonly=readonly
-    }}
-    {{flexberry-validationmessage error=model.errors.files pointing="pointing"}}
-  </div>
-  <div class="field">
-    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.userVotes-caption"}}</label>
-    {{flexberry-groupedit
-      componentName="suggestionUserVotesGroupEdit"
-      content=model.userVotes
-      mainModelProjection=modelProjection
-      modelProjection=modelProjection.attributes.userVotes
-      orderable=true
-      readonly=readonly
-    }}
-    {{flexberry-validationmessage error=model.errors.userVotes pointing="pointing"}}
-  </div>
-  <div class="field">
-    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.comments-caption"}}</label>
-    {{flexberry-groupedit
-      componentName="suggestionCommentsGroupEdit"
-      content=model.comments
-      mainModelProjection=modelProjection
-      modelProjection=modelProjection.attributes.comments
-      rowClickable=true
-      rowClick="rowClick"
-      editOnSeparateRoute=true
-      editFormRoute=commentsEditRoute
-      saveBeforeRouteLeave=true
-      orderable=true
-      readonly=readonly
-    }}
-    {{flexberry-validationmessage error=model.errors.comments pointing="pointing"}}
-  </div>
+<div class="field {{if model.errors.address "error" ""}}">
+  {{flexberry-field
+    value=model.address
+    label=(t "forms.ember-flexberry-dummy-suggestion-edit.address-caption")
+    readonly=readonly
+  }}
+</div>
+<div class="field {{if model.errors.text "error" ""}}">
+  {{flexberry-field
+    value=model.text
+    label=(t "forms.ember-flexberry-dummy-suggestion-edit.text-caption")
+    readonly=readonly
+  }}
+</div>
+<div class="field {{if model.errors.date "error" ""}}">
+  <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.date-caption"}}</label>
+  {{flexberry-simpledatetime
+    type="date"
+    value=model.date
+    readonly=readonly
+  }}
+</div>
+<div class="field {{if model.errors.votes "error" ""}}">
+  {{flexberry-field
+    value=model.votes
+    label=(t "forms.ember-flexberry-dummy-suggestion-edit.votes-caption")
+    readonly=readonly
+  }}
+</div>
+<div class="field">
+  <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.comments-caption"}}</label>
+  {{flexberry-groupedit
+    componentName="suggestionCommentsGroupEdit"
+    content=model.comments
+    mainModelProjection=modelProjection
+    modelProjection=modelProjection.attributes.comments
+    showDeleteButtonInRow = true
+    orderable=true
+    readonly=readonly
+  }}
+</div>

--- a/tests/dummy/app/templates/components-acceptance-tests/flexberry-groupedit/delete-with-details.hbs
+++ b/tests/dummy/app/templates/components-acceptance-tests/flexberry-groupedit/delete-with-details.hbs
@@ -1,0 +1,140 @@
+  <div class="field {{if model.errors.address "error" ""}}">
+    {{flexberry-field
+      value=model.address
+      label=(t "forms.ember-flexberry-dummy-suggestion-edit.address-caption")
+      readonly=readonly
+    }}
+    {{flexberry-validationmessage error=model.errors.address pointing="pointing"}}
+  </div>
+  <div class="field {{if model.errors.text "error" ""}}">
+    {{flexberry-field
+      value=model.text
+      label=(t "forms.ember-flexberry-dummy-suggestion-edit.text-caption")
+      readonly=readonly
+    }}
+    {{flexberry-validationmessage error=model.errors.text pointing="pointing"}}
+  </div>
+  <div class="field {{if model.errors.date "error" ""}}">
+    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.date-caption"}}</label>
+    {{flexberry-simpledatetime
+      type="date"
+      value=model.date
+      readonly=readonly
+    }}
+    {{flexberry-validationmessage error=model.errors.date pointing="pointing"}}
+  </div>
+  <div class="field {{if model.errors.votes "error" ""}}">
+    {{flexberry-field
+      value=model.votes
+      label=(t "forms.ember-flexberry-dummy-suggestion-edit.votes-caption")
+      readonly=readonly
+    }}
+    {{flexberry-validationmessage error=model.errors.votes pointing="pointing"}}
+  </div>
+  <div class="field {{if model.errors.moderated "error" ""}}">
+    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.moderated-caption"}}</label>
+    {{flexberry-checkbox
+      value=model.moderated
+      readonly=readonly
+    }}
+    {{flexberry-validationmessage error=model.errors.moderated pointing="pointing"}}
+  </div>
+  <div class="field {{if model.errors.type "error" ""}}">
+    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.type-caption"}}</label>
+    {{flexberry-lookup
+      value=model.type
+      relatedModel=model
+      relationName="type"
+      projection="SuggestionTypeL"
+      displayAttributeName="name"
+      title=(t "forms.ember-flexberry-dummy-suggestion-edit.type-caption")
+      choose=(action "showLookupDialog")
+      remove=(action "removeLookupValue")
+      dropdown=true
+      readonly=readonly
+      direction="upward"
+      componentName="SuggestionEditType"
+    }}
+    {{flexberry-validationmessage error=model.errors.type pointing="pointing"}}
+  </div>
+  <div class="field {{if model.errors.author "error" ""}}">
+    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.author-caption"}}</label>
+    {{flexberry-lookup
+      value=model.author
+      relatedModel=model
+      relationName="author"
+      projection="ApplicationUserL"
+      displayAttributeName="name"
+      showPreviewButton=true
+      previewOnSeparateRoute=true
+      previewFormRoute="ember-flexberry-dummy-application-user-edit"
+      title=(t "forms.ember-flexberry-dummy-suggestion-edit.author-caption")
+      choose=(action "showLookupDialog")
+      remove=(action "removeLookupValue")
+      preview=(action "previewLookupValue")
+      lookupWindowCustomProperties=(action 'getLookupFolvProperties')
+      readonly=readonly
+      componentName="SuggestionEditAuthor"
+    }}
+    {{flexberry-validationmessage error=model.errors.author pointing="pointing"}}
+  </div>
+  <div class="field {{if model.errors.editor1 "error" ""}}">
+    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.editor1-caption"}}</label>
+    {{flexberry-lookup
+      value=model.editor1
+      relatedModel=model
+      relationName="editor1"
+      projection="ApplicationUserL"
+      displayAttributeName="name"
+      showPreviewButton=true
+      previewFormRoute="ember-flexberry-dummy-application-user-edit"
+      title=(t "forms.ember-flexberry-dummy-suggestion-edit.editor1-caption")
+      choose=(action "showLookupDialog")
+      remove=(action "removeLookupValue")
+      preview=(action "previewLookupValue")
+      readonly=readonly
+      componentName="SuggestionEditEditor1"
+    }}
+    {{flexberry-validationmessage error=model.errors.editor1 pointing="pointing"}}
+  </div>
+  <div class="field">
+    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.files-caption"}}</label>
+    {{flexberry-groupedit
+      componentName="filesGroupEdit"
+      content=model.files
+      mainModelProjection=modelProjection
+      modelProjection=modelProjection.attributes.files
+      orderable=true
+      readonly=readonly
+    }}
+    {{flexberry-validationmessage error=model.errors.files pointing="pointing"}}
+  </div>
+  <div class="field">
+    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.userVotes-caption"}}</label>
+    {{flexberry-groupedit
+      componentName="suggestionUserVotesGroupEdit"
+      content=model.userVotes
+      mainModelProjection=modelProjection
+      modelProjection=modelProjection.attributes.userVotes
+      orderable=true
+      readonly=readonly
+    }}
+    {{flexberry-validationmessage error=model.errors.userVotes pointing="pointing"}}
+  </div>
+  <div class="field">
+    <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.comments-caption"}}</label>
+    {{flexberry-groupedit
+      componentName="suggestionCommentsGroupEdit"
+      content=model.comments
+      mainModelProjection=modelProjection
+      modelProjection=modelProjection.attributes.comments
+      rowClickable=true
+      rowClick="rowClick"
+      editOnSeparateRoute=true
+      editFormRoute=commentsEditRoute
+      saveBeforeRouteLeave=true
+      orderable=true
+      readonly=readonly
+    }}
+    {{flexberry-validationmessage error=model.errors.comments pointing="pointing"}}
+  </div>

--- a/tests/dummy/app/templates/components-acceptance-tests/flexberry-groupedit/delete-with-details.hbs
+++ b/tests/dummy/app/templates/components-acceptance-tests/flexberry-groupedit/delete-with-details.hbs
@@ -27,15 +27,12 @@
     readonly=readonly
   }}
 </div>
-<div class="field">
-  <label>{{t "forms.ember-flexberry-dummy-suggestion-edit.comments-caption"}}</label>
-  {{flexberry-groupedit
-    componentName="suggestionCommentsGroupEdit"
-    content=model.comments
-    mainModelProjection=modelProjection
-    modelProjection=modelProjection.attributes.comments
-    showDeleteButtonInRow = true
-    orderable=true
-    readonly=readonly
-  }}
-</div>
+{{flexberry-groupedit
+  componentName="suggestionCommentsGroupEdit"
+  content=model.comments
+  mainModelProjection=modelProjection
+  modelProjection=modelProjection.attributes.comments
+  showDeleteButtonInRow = true
+  orderable=true
+  readonly=readonly
+}}

--- a/tests/dummy/app/templates/components-acceptance-tests/flexberry-objectlistview/delete-with-details.hbs
+++ b/tests/dummy/app/templates/components-acceptance-tests/flexberry-objectlistview/delete-with-details.hbs
@@ -24,6 +24,5 @@
   deleteButton=true
   rowClickable=rowClickable
   data-test-olv=true
-  immediateDelete = immediateDelete
   showDeleteButtonInRow=true
 }}

--- a/tests/dummy/app/templates/components-acceptance-tests/flexberry-objectlistview/delete-with-details.hbs
+++ b/tests/dummy/app/templates/components-acceptance-tests/flexberry-objectlistview/delete-with-details.hbs
@@ -25,4 +25,5 @@
   rowClickable=rowClickable
   data-test-olv=true
   immediateDelete = immediateDelete
+  showDeleteButtonInRow=true
 }}

--- a/tests/dummy/app/templates/components-acceptance-tests/flexberry-objectlistview/delete-with-details.hbs
+++ b/tests/dummy/app/templates/components-acceptance-tests/flexberry-objectlistview/delete-with-details.hbs
@@ -1,0 +1,28 @@
+{{flexberry-objectlistview
+  editFormRoute=editFormRoute
+  showCheckBoxInRow=true
+  modelName="ember-flexberry-dummy-suggestion"
+  modelProjection=modelProjection
+  content=model
+  createNewButton=true
+  refreshButton=true
+  sorting=computedSorting
+  orderable=true
+  sortByColumn=(action "sortByColumn")
+  addColumnToSorting=(action "addColumnToSorting")
+  pages=pages
+  perPageValue=perPageValue
+  perPageValues=perPageValues
+  recordsTotalCount=recordsTotalCount
+  hasPreviousPage=hasPreviousPage
+  hasNextPage=hasNextPage
+  previousPage=(action "previousPage")
+  gotoPage=(action "gotoPage")
+  nextPage=(action "nextPage")
+  componentName="FOLVSettingExampleObjectListView"
+  showDeleteMenuItemInRow=true
+  deleteButton=true
+  rowClickable=rowClickable
+  data-test-olv=true
+  immediateDelete = immediateDelete
+}}


### PR DESCRIPTION
Ранее при удалении записи с детейлами на каждый детейл посылался отдельный запрос на удаление детейла. Теперь удаляется только сама запись, а детейловые записи выгружаются. Удаление происходит непосредственно в ORM или в случае офлайна в его адаптере.

Данный ПР пройдёт билд, когда будет доступна ember-flexberry-data 2.7.0-beta.1.