### PR TITLE
Фикс. Слет дефолтных настроек лукапов при обновлении контента в OLV

### DIFF
--- a/addon/controllers/lookup-dialog.js
+++ b/addon/controllers/lookup-dialog.js
@@ -282,7 +282,7 @@ export default ListFormController.extend(SortableRouteMixin, PredicateFromFilter
         };
 
         let userSettingsService = this.get('userSettingsService');
-        userSettingsService.setCurrentParams(folvComponentName, userSettingsParams);
+        userSettingsService.setCurrentParams(folvComponentName, userSettingsParams, this.get('modelName'));
       }
 
       reloadDataHandler(this.get('reloadContext'), reloadData);

--- a/addon/services/user-settings.js
+++ b/addon/services/user-settings.js
@@ -289,11 +289,22 @@ export default Service.extend({
    @param {Object} params
    @return {String} URL params
    */
-  setCurrentParams(componentName, params) {
+  setCurrentParams(componentName, params, modelName) {
     let appPage = this.currentAppPage;
+    let userSetting;
+    if(!isNone(modelName)) {
+      const userSettingValue = getOwner(this).lookup('default-user-setting:' + modelName);
+      if (!isNone(userSettingValue)) {
+        userSetting = userSettingValue.DEFAULT;
+      }
+    }
+
     if (params.sort === null) {
+      if(!isNone(userSetting)) {
+        this.saveUserSetting(componentName, defaultSettingName, userSetting);
+      }
+
       this.currentUserSettings[appPage][componentName][defaultSettingName].sorting = this.getCurrentSorting(componentName);
-      return serializeSortingParam(this.currentUserSettings[appPage][componentName][defaultSettingName].sorting);
     } else {
       let sorting;
       if ('sort' in params && params.sort) {
@@ -302,12 +313,13 @@ export default Service.extend({
         sorting = this.beforeParamUserSettings[appPage][componentName][defaultSettingName].sorting;
       }
 
-      let userSetting = this.getCurrentUserSetting(componentName);
+      userSetting = this.getCurrentUserSetting(componentName);
       userSetting.sorting = sorting;
       this.saveUserSetting(componentName, defaultSettingName, userSetting);
       this.currentUserSettings[appPage][componentName][defaultSettingName].sorting = sorting;
-      return serializeSortingParam(this.currentUserSettings[appPage][componentName][defaultSettingName].sorting);
     }
+
+    return serializeSortingParam(this.currentUserSettings[appPage][componentName][defaultSettingName].sorting);
   },
 
   /**


### PR DESCRIPTION
Правки:
- при обновлении OLV сохранять default-user-setеings если такие есть 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Новые возможности
  * Настройки пользователя теперь сохраняются и применяются отдельно для каждой модели, что обеспечивает персонализацию в разных разделах.
  * Добавлена поддержка предустановленных (дефолтных) настроек на основе модели.

* Улучшения
  * Более стабильное и предсказуемое применение сортировки: корректное сохранение и восстановление текущей сортировки, в том числе после перезагрузки и при отсутствии параметров сортировки.
  * Единообразный возврат актуальных параметров сортировки для интерфейса, что снижает вероятность несоответствий в отображении данных.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->