### PR TITLE
Фикс. Перезапись дефолтных настроек лукапов при обновлении контента в OLV

### DIFF
--- a/.eslint-todo-errors.json
+++ b/.eslint-todo-errors.json
@@ -603,14 +603,14 @@
     { "ruleId": "ember/use-ember-get-and-set", "line": 210, "column": 52 },
     { "ruleId": "ember/use-ember-get-and-set", "line": 211, "column": 44 },
     { "ruleId": "ember/use-ember-get-and-set", "line": 212, "column": 49 },
-    { "ruleId": "no-undef", "line": 485, "column": 37 },
-    { "ruleId": "ember/use-ember-get-and-set", "line": 741, "column": 56 },
-    { "ruleId": "ember/use-ember-get-and-set", "line": 756, "column": 23 },
-    { "ruleId": "ember/use-ember-get-and-set", "line": 761, "column": 23 },
-    { "ruleId": "ember/use-ember-get-and-set", "line": 762, "column": 23 },
-    { "ruleId": "ember/use-ember-get-and-set", "line": 763, "column": 23 },
+    { "ruleId": "no-undef", "line": 488, "column": 37 },
+    { "ruleId": "ember/use-ember-get-and-set", "line": 744, "column": 56 },
+    { "ruleId": "ember/use-ember-get-and-set", "line": 759, "column": 23 },
     { "ruleId": "ember/use-ember-get-and-set", "line": 764, "column": 23 },
-    { "ruleId": "ember/use-ember-get-and-set", "line": 765, "column": 23 }
+    { "ruleId": "ember/use-ember-get-and-set", "line": 765, "column": 23 },
+    { "ruleId": "ember/use-ember-get-and-set", "line": 766, "column": 23 },
+    { "ruleId": "ember/use-ember-get-and-set", "line": 767, "column": 23 },
+    { "ruleId": "ember/use-ember-get-and-set", "line": 768, "column": 23 }
   ],
   "addon/utils/extended-get.js": [
     { "ruleId": "ember/use-ember-get-and-set", "line": 29, "column": 23 },
@@ -732,12 +732,6 @@
     { "ruleId": "no-extra-semi", "line": 31, "column": 2 },
     { "ruleId": "no-extra-semi", "line": 40, "column": 2 },
     { "ruleId": "no-extra-semi", "line": 55, "column": 2 }
-  ],
-  "config/ember-try.js": [
-    { "ruleId": "node/no-missing-require", "line": 3, "column": 31 }
-  ],
-  "ember-cli-build.js": [
-    { "ruleId": "node/no-missing-require", "line": 4, "column": 30 }
   ],
   "tests/acceptance/components/base-flexberry-lookup-test.js": [
     { "ruleId": "ember/use-ember-get-and-set", "line": 128, "column": 27 },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Ember Flexberry Changelog
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
+## [3.13.2-beta.3] - 2026-02-03
+### Fixed
+* Fix overwriting default usersettings.
+
 ## [3.13.2-beta.2] - 2026-01-15
 ### Fixed
 * Fix default usersettings.

--- a/addon/services/user-settings.js
+++ b/addon/services/user-settings.js
@@ -313,7 +313,10 @@ export default Service.extend({
         sorting = this.beforeParamUserSettings[appPage][componentName][defaultSettingName].sorting;
       }
 
-      userSetting = this.getCurrentUserSetting(componentName);
+      if (isNone(userSetting)) {
+        userSetting = this.getCurrentUserSetting(componentName);
+      }
+
       userSetting.sorting = sorting;
       this.saveUserSetting(componentName, defaultSettingName, userSetting);
       this.currentUserSettings[appPage][componentName][defaultSettingName].sorting = sorting;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-flexberry",
-  "version": "3.13.2-beta.2",
+  "version": "3.13.2-beta.3",
   "description": "Ember Flexberry Addon",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
При обновлении OLV в userSetting задаются значения по умолчанию, но потом перезатирались. Добавлено условие для избегания такой ситуации.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Исправлено поведение при применении пользовательской сортировки: добавлена проверка/инициализация настроек перед сохранением, что предотвращает перезапись значений по умолчанию и обеспечивает корректное применение сортировки.

* **Прочие изменения**
  * Обновлён номер версии до 3.13.2-beta.3 и добавлена соответствующая запись в журнал изменений.
  * Обновлены данные о проверках линтинга/todo (метаданные).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->