### PR TITLE
Пример с загрузкой вложенных мастеров через OData Actions (для ODataService v6.1.1-beta02)

### DIFF
--- a/tests/dummy/app/controllers/integration-examples/odata-examples/get-masters/ember-flexberry-dummy-sotrudnik-l.js
+++ b/tests/dummy/app/controllers/integration-examples/odata-examples/get-masters/ember-flexberry-dummy-sotrudnik-l.js
@@ -43,6 +43,30 @@ export default ListFormController.extend({
             }
           }
         });
+    },
+
+    doOdataAction() {
+      const adapter = get(this, 'store').adapterFor('application');
+      let args = {
+        actionName: 'GetMastersForTestAction?__autoExpand=true',
+      };
+
+      adapter.callAction(args)
+        .then(sotrudniks => {
+          if (!isEmpty(sotrudniks.value)) {
+            set(this, 'dataReceived', true);
+            let departaments = sotrudniks.value.map((a) => get(a, 'Departament'));
+            let departamentsIsNull = sotrudniks.value.find((a) => isNone(get(a, 'Departament')));
+            if (!isEmpty(departaments) && isNone(departamentsIsNull)) {
+              set(this, 'receivedMasters', true);
+              let vid = departaments.map((a) => get(a, 'Vid'));
+              let vidIsNull = departaments.find((a) => isNone(get(a, 'Vid')));
+              if (!isEmpty(vid) && isNone(vidIsNull)) {
+                set(this, 'receivedMasterMasters', true);
+              }
+            }
+          }
+        });
     }
   }
 });

--- a/tests/dummy/app/locales/en/translations.js
+++ b/tests/dummy/app/locales/en/translations.js
@@ -1177,6 +1177,7 @@ $.extend(true, translations, {
           'ember-flexberry-dummy-sotrudnik-l': {
             caption: 'EmberFlexberryDummySotrudnikL',
             'doOdataFunction': 'Do Odata function',
+            'doOdataAction': 'Do Odata action',
             'dataReceived': 'Objects loaded',
             'receivedMasters': 'Masters loaded',
             'receivedMastersError': 'Error loading masters',

--- a/tests/dummy/app/locales/ru/translations.js
+++ b/tests/dummy/app/locales/ru/translations.js
@@ -1186,6 +1186,7 @@ $.extend(true, translations, {
           'ember-flexberry-dummy-sotrudnik-l': {
             caption: 'Сотрудники',
             'doOdataFunction': 'Выполнить Odata функцию',
+            'doOdataAction': 'Выполнить Odata экшен',
             'dataReceived': 'Объекты загружены',
             'receivedMasters': 'Мастера загружены',
             'receivedMastersError': 'Ошибка загрузки мастеров',

--- a/tests/dummy/app/templates/integration-examples/odata-examples/get-masters/ember-flexberry-dummy-sotrudnik-l.hbs
+++ b/tests/dummy/app/templates/integration-examples/odata-examples/get-masters/ember-flexberry-dummy-sotrudnik-l.hbs
@@ -30,6 +30,9 @@
 <button type="button" class="ui button" {{action "doOdataFunction" on="click"}}>
   {{t "forms.integration-examples.odata-examples.get-masters.ember-flexberry-dummy-sotrudnik-l.doOdataFunction"}}
 </button>
+<button type="button" class="ui button" {{action "doOdataAction" on="click"}}>
+  {{t "forms.integration-examples.odata-examples.get-masters.ember-flexberry-dummy-sotrudnik-l.doOdataAction"}}
+</button>
 
 {{#if dataReceived}}
   <div class="field">


### PR DESCRIPTION
Пример с загрузкой вложенных мастеров через OData Actions (только для версии ODataService `6.1.1-beta02`).